### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,4 +1,4 @@
-name: Build and publish to PyPI
+name: Publish
 
 on:
   release:
@@ -55,6 +55,7 @@ jobs:
   pypi-publish:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
+    needs: build
     environment:
       name: release
       url: https://pypi.org/project/chainbench

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@
 </p>
 
 # Chainbench
+![checks status](https://github.com/chainstacklabs/chainbench/actions/workflows/checks.yml/badge.svg) 
+![build status](https://github.com/chainstacklabs/chainbench/actions/workflows/python-publish.yml/badge.svg)
+![version](https://img.shields.io/pypi/v/chainbench)
+![license](https://img.shields.io/github/license/chainstacklabs/chainbench)
 
 This project allows you to benchmark your blockchain infrastructure. It uses [Locust](https://docs.locust.io/en/stable/index.html) under the hood.
 
@@ -47,7 +51,14 @@ Check out the [docs](docs/PROFILE.md) for more information about the profile cre
 
 ### Using pip
 
-> ⚠️ Installation using pip is not supported yet.
+```shell
+pip install chainbench
+```
+
+After installation, you can run the tool using the following command:
+```shell
+chainbench start --help
+```
 
 ### Using Poetry
 
@@ -61,20 +72,22 @@ Install dependencies:
 cd chainbench && poetry install --without dev
 ```
 
-You might need to run the following command before running the tool:
+When installing using Poetry, you can run the tool using the following command:
 ```shell
-poetry shell
+poetry run chainbench start --help
 ```
 
 ## Example Usage
+All the examples below assume that you have installed the tool using `pip`. If you installed it using `poetry`, replace `chainbench` with `poetry run chainbench`.
+
 To learn about the parameters and flags, run the following command:
 ```shell
-python3 -m chainbench start --help
+chainbench start --help
 ```
 
 Basic usage is:
 ```shell
-python3 -m chainbench start --profile bsc --users 50 --workers 2 --test-time 12h --target https://node-url --headless --autoquit
+chainbench start --profile bsc --users 50 --workers 2 --test-time 12h --target https://node-url --headless --autoquit
 ```
 
 This will run a load test for BSC with 2 workers, 50 users and 12 hours test time in headless mode.
@@ -99,7 +112,7 @@ Run the following command to run a load test for BSC in UI mode. It will start a
 Target is not required as you can specify it in the UI along with the number of users, spawn rate and test time.
 
 ```shell
-python3 -m chainbench start --profile bsc --workers 1
+chainbench start --profile bsc --workers 1
 ```
 
 ### Headless Mode
@@ -107,7 +120,7 @@ python3 -m chainbench start --profile bsc --workers 1
 If you want to run a load test for BSC in headless mode, run the following command:
 
 ```shell
-python3 -m chainbench start --profile bsc --workers 4 --users 100 --test-time 1h --target https://node-url --headless --autoquit
+chainbench start --profile bsc --workers 4 --users 100 --test-time 1h --target https://node-url --headless --autoquit
 ```
 
 It will run a load test for BSC with 4 workers, 100 users and 1 hour test time.
@@ -115,7 +128,7 @@ It will run a load test for BSC with 4 workers, 100 users and 1 hour test time.
 In practice, you will probably want to run the benchmark on a remote server. Here's the example utilizing `nohup`:
 
 ```shell
-nohup python3 -m chainbench start --profile bsc --workers 4 --users 100 --test-time 1h --target https://node-url --headless --autoquit &
+nohup chainbench start --profile bsc --workers 4 --users 100 --test-time 1h --target https://node-url --headless --autoquit &
 ```
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chainbench"
-version = "0.1.0"
+version = "0.1.1"
 description = ""
 authors = ["Egor Molodik <egor.molodik@chainstack.com>"]
 readme = "README.md"
@@ -20,6 +20,9 @@ pre-commit = "^3.2.2"
 flake8 = "^6.0.0"
 isort = "^5.12.0"
 flake8-pyproject = "^1.2.3"
+
+[tool.poetry.scripts]
+chainbench = "chainbench.main:cli"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Change the publishing workflow to wait until the build job finishes before starting the publishing job. Also, update the readme with the installation example using `pip`.