### PR TITLE
Profile discovery improvements and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,32 @@ After the test is finished, the tool will automatically quit.
 - `--autoquit`: This flag tells the Chainbench tool to automatically quit after the test has finished. This is useful for running the benchmark in an automated environment where manual intervention is not desired.
 - `--help`: This flag displays the help message.
 
+By default, Chainbench uses `constant_pacing` wait time with a value of 10 seconds. 
+This means a load test with 100 users will have a theoretical maximum of 10 rps. This allows us to have a target rps in a test, 
+and the result rps lower than the target rps means performance deterioration.
+
 ### Profiles
-Profiles are located in the [`profile`](chainbench/profile) directory. For a tutorial on how to create custom profiles, please refer to [this document](docs/PROFILE.md).
+Default profiles are located in the [`profile`](chainbench/profile) directory. For a tutorial on how to create custom profiles, please refer to [this document](docs/PROFILE.md).
+
+You can also use the `--profile-dir` flag to specify a custom directory with profiles. For example:
+```shell
+chainbench start --profile-dir /path/to/profiles --profile my-profile --users 50 --workers 2 --test-time 12h --target https://node-url --headless --autoquit
+```
+This will run a load test using `/path/to/profiles/my-profile.py` profile.
+
+It's possible to group profiles into directories. For example, you can create a directory called `bsc` and put all the BSC profiles there. Then you can run a load test using the following command:
+```shell
+chainbench start --profile-dir /path/to/profiles --profile bsc.my-profile --users 50 --workers 2 --test-time 12h --target https://node-url --headless --autoquit
+```
+
+Chainbench will look for the profile in `/path/to/profiles/bsc/my-profile.py`. Currently, only one level of nesting is supported.
+
+There are built-in `evm.light` and `evm.heavy` profiles for EVM-compatible chains.
+
+Here's an example of how to run a load test for Ethereum using the `evm.light` profile:
+```shell
+chainbench start --profile evm.light --users 50 --workers 2 --test-time 12h --target https://node-url --headless --autoquit
+```
 
 ### Web UI Mode
 

--- a/chainbench/profile/ethereum.py
+++ b/chainbench/profile/ethereum.py
@@ -15,7 +15,7 @@ pie title Methods Distribution
     "Others" : 12
 ```
 """
-from locust import task
+from locust import tag, task
 
 from chainbench.user.evm import EVMBenchUser
 
@@ -91,8 +91,8 @@ class EthereumProfile(EVMBenchUser):
             params=self._get_logs_params_factory(),
         ),
 
-    # TODO: introduce tags to make it possible to filter out unsupported methods
-    # @task(3)
+    @tag("debug")
+    @task(3)
     def trace_transaction_task(self):
         self.make_call(
             name="trace_transaction",

--- a/chainbench/profile/evm/heavy.py
+++ b/chainbench/profile/evm/heavy.py
@@ -1,0 +1,32 @@
+"""
+Ethereum profile (heavy mode).
+"""
+from locust import task
+
+from chainbench.user.evm import EVMBenchUser
+
+
+class EthereumHeavyProfile(EVMBenchUser):
+    @task
+    def trace_transaction_task(self):
+        self.make_call(
+            name="trace_transaction",
+            method="debug_traceTransaction",
+            params=[],
+        ),
+
+    @task
+    def block_task(self):
+        self.make_call(
+            name="block",
+            method="trace_block",
+            params=self._block_by_number_params_factory(),
+        ),
+
+    @task
+    def get_logs_task(self):
+        self.make_call(
+            name="get_logs",
+            method="eth_getLogs",
+            params=self._get_logs_params_factory(),
+        ),

--- a/chainbench/profile/evm/light.py
+++ b/chainbench/profile/evm/light.py
@@ -1,0 +1,64 @@
+"""
+Ethereum profile (light mode).
+"""
+from locust import task
+
+from chainbench.user.evm import EVMBenchUser
+
+
+class EthereumLightProfile(EVMBenchUser):
+    @task
+    def get_transaction_receipt_task(self):
+        self.make_call(
+            name="get_transaction_receipt",
+            method="eth_getTransactionReceipt",
+            params=self._transaction_by_hash_params_factory(),
+        ),
+
+    @task
+    def block_number_task(self):
+        self.make_call(
+            name="block_number",
+            method="eth_blockNumber",
+            params=[],
+        ),
+
+    @task
+    def get_balance_task(self):
+        self.make_call(
+            name="get_balance",
+            method="eth_getBalance",
+            params=self._get_balance_params_factory_latest(),
+        ),
+
+    @task
+    def chain_id_task(self):
+        self.make_call(
+            name="chain_id",
+            method="eth_chainId",
+            params=[],
+        ),
+
+    @task
+    def get_block_by_number_task(self):
+        self.make_call(
+            name="get_block_by_number",
+            method="eth_getBlockByNumber",
+            params=self._block_by_number_params_factory(),
+        ),
+
+    @task
+    def get_transaction_by_hash_task(self):
+        self.make_call(
+            name="get_transaction_by_hash",
+            method="eth_getTransactionByHash",
+            params=self._transaction_by_hash_params_factory(),
+        ),
+
+    @task
+    def client_version_task(self):
+        self.make_call(
+            name="client_version",
+            method="web3_clientVersion",
+            params=[],
+        ),

--- a/chainbench/profile/polygon.py
+++ b/chainbench/profile/polygon.py
@@ -18,7 +18,7 @@ pie title Methods Distribution
     "Others" : 9
 ```
 """
-from locust import task
+from locust import tag, task
 
 from chainbench.user.evm import EVMBenchUser
 
@@ -95,7 +95,8 @@ class PolygonProfile(EVMBenchUser):
         ),
 
     # TODO: introduce tags to make it possible to filter out unsupported methods
-    # @task(2)
+    @tag("trace")
+    @task(2)
     def block_task(self):
         self.make_call(
             name="block",

--- a/chainbench/profile/polygon.py
+++ b/chainbench/profile/polygon.py
@@ -94,7 +94,6 @@ class PolygonProfile(EVMBenchUser):
             params=self._get_balance_params_factory_latest(),
         ),
 
-    # TODO: introduce tags to make it possible to filter out unsupported methods
     @tag("trace")
     @task(2)
     def block_task(self):

--- a/chainbench/user/base.py
+++ b/chainbench/user/base.py
@@ -36,15 +36,15 @@ class BaseBenchUser(FastHttpUser):
 
     def check_fatal(self, response: RestResponseContextManager):
         if response.status_code == 401:
-            self.logger.critical(f"⛔️ Unauthorized request to {response.url}")
+            self.logger.critical(f"Unauthorized request to {response.url}")
         elif response.status_code == 404:
-            self.logger.critical(f"⛔️ Not found: {response.url}")
+            self.logger.critical(f"Not found: {response.url}")
         elif 500 <= response.status_code <= 599:
             self.logger.critical(
-                f"⛔️ Got internal server error when requesting {response.url}"
+                f"Got internal server error when requesting {response.url}"
             )
         elif 300 <= response.status_code <= 399:
-            self.logger.critical(f"⛔️ Redirect error: {response.url}")
+            self.logger.critical(f"Redirect error: {response.url}")
 
     def check_response(self, response: RestResponseContextManager):
         """Check the response for errors."""

--- a/chainbench/util/cli.py
+++ b/chainbench/util/cli.py
@@ -6,10 +6,20 @@ from pathlib import Path
 from chainbench.util.notify import NoopNotifier, Notifier
 
 
-def get_profile_path(profile: str, src_path: str | Path) -> Path:
-    """Get profile path."""
+def get_base_path(src_path: str | Path) -> Path:
+    """Get base path."""
     curr_path = Path(src_path).resolve()
-    profile_path = curr_path.parent / f"profile/{profile}.py"
+    base_path = curr_path.parent / "profile"
+    return base_path
+
+
+def get_profile_path(base_path: Path, profile: str) -> Path:
+    """Get profile path."""
+    subdir, _, profile = profile.rpartition(".")
+    if subdir:
+        profile_path = base_path / subdir / f"{profile}.py"
+    else:
+        profile_path = base_path / f"{profile}.py"
     return profile_path
 
 
@@ -42,6 +52,7 @@ def get_master_command(
     results_path: Path,
     target: str | None = None,
     headless: bool = False,
+    exclude_tags: list[str] | None = None,
 ) -> str:
     """Generate master command."""
     command = (
@@ -59,6 +70,9 @@ def get_master_command(
     if headless:
         command += " --headless"
 
+    if exclude_tags:
+        command += f" --exclude-tags {' '.join(exclude_tags)}"
+
     return command
 
 
@@ -71,6 +85,7 @@ def get_worker_command(
     target: str | None = None,
     headless: bool = False,
     worker_id: int = 0,
+    exclude_tags: list[str] | None = None,
 ) -> str:
     """Generate worker command."""
     command = (
@@ -83,6 +98,9 @@ def get_worker_command(
 
     if headless:
         command += " --headless"
+
+    if exclude_tags:
+        command += f" --exclude-tags {' '.join(exclude_tags)}"
 
     return command
 

--- a/chainbench/util/event.py
+++ b/chainbench/util/event.py
@@ -32,12 +32,12 @@ def on_test_stop(environment, **_kwargs):
     if not isinstance(runner, MasterRunner):
         # Print worker details to the log
         logger.info(
-            f"🏁 Worker[{runner.worker_index:02d}]: Tests completed in "
+            f"Worker[{runner.worker_index:02d}]: Tests completed in "
             f"{Timer.get_time_diff(runner.worker_index):>.3f} seconds"
         )
     else:
         # Print master details to the log
-        logger.info("🏁 Master: The test is stopped")
+        logger.info("Master: The test is stopped")
 
 
 # Listener for the init event
@@ -51,11 +51,11 @@ def on_init(environment, **_kwargs):
 
     if isinstance(environment.runner, MasterRunner):
         # Print master details to the log
-        logger.info("🤖 I'm a master. Running tests for %s", host_under_test)
+        logger.info("I'm a master. Running tests for %s", host_under_test)
 
     if isinstance(environment.runner, WorkerRunner):
         # Print worker details to the log
-        logger.info("🤖 I'm a worker. Running tests for %s", host_under_test)
+        logger.info("I'm a worker. Running tests for %s", host_under_test)
         logger.info("Initializing test data...")
         for user in environment.runner.user_classes:
             if not hasattr(user, "test_data"):


### PR DESCRIPTION
## Description

Please provide a brief description of the changes made in this pull request.

## Issues Resolved

Introduced several fixes made by @erwin-wee, including:
1. Make Chainbench Windows-friendly
2. Fix an issue with the primary process quitting before the result files were fully processed
3. Use constant_pacing wait time in the base user class with a value of 10 seconds. This means a load test with 100 users will have a theoretical maximum of 10 rps. This allows us to have a "target rps" in a test, and the result rps lower than the target rps means performance deterioration.


## Changes Made

1. Rework profile discovery mechanism. Now you can specify a directory in which your profiles are located using the `--profile-dir` option.
2. Support profile grouping. Now you can use the `namespace.profile` syntax to access profiles in a subdirectory.
3. Added `evm.light` and `evm.heavy` profiles.
4. Added tags to disable debug/trace calls in average profiles. 