### PR TITLE
Add Dockerfile for chainbench

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+*
+!api
+!chainbench
+!poetry.lock
+!pyproject.toml
+!README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.10-buster
 
+# Install dependencies
+RUN apt-get update && apt-get install -y tini
+
 # copy files
 COPY . /app
 WORKDIR /app
@@ -10,3 +13,5 @@ RUN $HOME/.local/bin/poetry config virtualenvs.create false
 
 # install chainbench
 RUN $HOME/.local/bin/poetry install --without dev
+
+ENTRYPOINT ["/usr/bin/tini", "--", "python3", "-m", "chainbench"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.10-buster
+
+# copy files
+COPY . /app
+WORKDIR /app
+
+# install poetry
+RUN curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.4.0 python3 -
+RUN $HOME/.local/bin/poetry config virtualenvs.create false
+
+# install chainbench
+RUN $HOME/.local/bin/poetry install --without dev


### PR DESCRIPTION
Dockerfile based on python:3.10-buster because installation pipeline requires gcc lib to be installed 

TODO: 

- [ ] add [tini](https://github.com/krallin/tini) as entrypoint for better docker experience
- [ ] add CI pipeline based on GitHub actions to create new tag and new image for `main` branch