### PR TITLE
Add evm debug trace profile

### DIFF
--- a/chainbench/profile/evm/debug_trace.py
+++ b/chainbench/profile/evm/debug_trace.py
@@ -1,0 +1,44 @@
+"""
+Ethereum profile (heavy mode).
+"""
+
+from locust import constant_pacing, task
+
+from chainbench.user.evm import EVMBenchUser
+from chainbench.util.rng import get_rng
+
+
+class EthereumDebugTraceProfile(EVMBenchUser):
+    wait_time = constant_pacing(10)
+
+    @task(324)
+    def debug_trace_transaction_task(self):
+        self.make_call(
+            name="debug_trace_transaction",
+            method="debug_traceTransaction",
+            params=self._trace_transaction_params_factory(get_rng()),
+        ),
+
+    @task(41)
+    def debug_trace_call_task(self):
+        self.make_call(
+            name="debug_trace_call",
+            method="debug_traceCall",
+            params=self._trace_call_params_factory(get_rng()),
+        ),
+
+    @task(36)
+    def debug_trace_block_by_number_task(self):
+        self.make_call(
+            name="debug_trace_block_by_number",
+            method="debug_traceBlockByNumber",
+            params=self._trace_block_by_number_params_factory(get_rng()),
+        ),
+
+    @task(1)
+    def debug_trace_block_by_hash_task(self):
+        self.make_call(
+            name="debug_trace_block_by_hash",
+            method="debug_traceBlockByHash",
+            params=self._trace_block_by_hash_params_factory(get_rng()),
+        ),

--- a/chainbench/test_data/base.py
+++ b/chainbench/test_data/base.py
@@ -189,6 +189,11 @@ class BaseTestData:
             rng = get_rng()
         return rng.random.choice(self.tx_hashes)
 
+    def get_random_tx(self, rng: RNG | None = None) -> Tx:
+        if rng is None:
+            rng = get_rng()
+        return rng.random.choice(self.txs)
+
     def get_random_recent_block_number(self, n: int, rng: RNG | None = None) -> BlockNumber:
         if rng is None:
             rng = get_rng()

--- a/chainbench/test_data/evm.py
+++ b/chainbench/test_data/evm.py
@@ -83,7 +83,7 @@ class EVMTestData(BaseTestData):
             return start_block_number, end_block_number
         else:
             end_block_number = self._fetch_latest_block_number()
-            start_block_number = end_block_number - 20
+            start_block_number = end_block_number - 10000
             logger.info("Using recent blocks from %s to %s as test data", start_block_number, end_block_number)
             return start_block_number, end_block_number
 
@@ -99,6 +99,11 @@ class EVMTestData(BaseTestData):
         start_block_number, end_block_number = self._get_start_and_end_blocks(parsed_options.use_recent_blocks)
 
         while self.TXS_REQUIRED > len(txs) or self.ACCOUNTS_REQUIRED > len(accounts) or self.SAVE_BLOCKS > len(blocks):
+            print(
+                f"txs = {len(txs)}/{self.TXS_REQUIRED}  "
+                f"accounts = {len(accounts)}/{self.ACCOUNTS_REQUIRED}  "
+                f"blocks = {len(blocks)}/{self.SAVE_BLOCKS}"
+            )
             if self.ACCOUNTS_REQUIRED > len(accounts) or self.TXS_REQUIRED > len(txs):
                 return_txs = True
             else:


### PR DESCRIPTION
## Description
- add evm.debug_trace locust profile
- add get_random_tx in test_data\base.py
- change default block range to 10000 instead of 20
- add print to console to display test data preparation progress
- add debug_traceCall params factory and add timeout to trace configs