### PR TITLE
fix check_response

### DIFF
--- a/chainbench/util/rpc.py
+++ b/chainbench/util/rpc.py
@@ -1,3 +1,6 @@
+import random
+
+
 def generate_request(method, params: list | dict | None = None, version: str = "2.0"):
     """Generate a JSON-RPC request."""
     if params is None:
@@ -7,5 +10,5 @@ def generate_request(method, params: list | dict | None = None, version: str = "
         "jsonrpc": version,
         "method": method,
         "params": params,
-        "id": 1,
+        "id": random.randint(1, 100000000),
     }


### PR DESCRIPTION
## Description
- fix check_response, json rpc errors are now displayed more cleanly without stack traces
- added rpc_error_code_exclusions property to exclude certain error codes from failing the response
- re-enabled random request id in generate_request method to enable matching of request -> response

## Issues Resolved
- json rpc errors were displayed with stack traces in Locust report, which was unnecessary