### PR TITLE
Feature: Dynamic Eth Call

### DIFF
--- a/chainbench/profile/avalanche/general.py
+++ b/chainbench/profile/avalanche/general.py
@@ -22,7 +22,7 @@ from chainbench.util.rng import get_rng
 
 
 class AvalancheProfile(EVMBenchUser):
-    wait_time = constant_pacing(2)
+    wait_time = constant_pacing(1)
     weight = 91
 
     @task(100)
@@ -44,7 +44,7 @@ class AvalancheProfile(EVMBenchUser):
         self.make_call(
             name="get_block_by_number",
             method="eth_getBlockByNumber",
-            params=self._block_params_factory(get_rng()),
+            params=self._block_params_factory(),
         ),
 
     @task(17)

--- a/chainbench/profile/bsc/general.py
+++ b/chainbench/profile/bsc/general.py
@@ -21,7 +21,7 @@ from chainbench.util.rng import get_rng
 
 
 class BscProfile(EVMBenchUser):
-    wait_time = constant_pacing(2)
+    wait_time = constant_pacing(1)
     weight = 89
 
     @task(100)
@@ -65,7 +65,7 @@ class BscProfile(EVMBenchUser):
         self.make_call(
             name="get_block_by_number",
             method="eth_getBlockByNumber",
-            params=self._block_params_factory(get_rng()),
+            params=self._block_params_factory(),
         ),
 
     @task(9)

--- a/chainbench/profile/ethereum/general.py
+++ b/chainbench/profile/ethereum/general.py
@@ -22,7 +22,7 @@ from chainbench.util.rng import get_rng
 
 
 class EthereumProfile(EVMBenchUser):
-    wait_time = constant_pacing(2)
+    wait_time = constant_pacing(1)
     weight = 487
 
     @task(100)
@@ -68,7 +68,7 @@ class EthereumProfile(EVMBenchUser):
         self.make_call(
             name="get_block_by_number",
             method="eth_getBlockByNumber",
-            params=self._block_params_factory(get_rng()),
+            params=self._block_params_factory(),
         ),
 
     @task(8)

--- a/chainbench/profile/ethereum/general.py
+++ b/chainbench/profile/ethereum/general.py
@@ -30,13 +30,7 @@ class EthereumProfile(EVMBenchUser):
         self.make_call(
             name="call",
             method="eth_call",
-            params=[
-                {
-                    "to": "0x8BB4C975Ff3c250e0ceEA271728547f3802B36Fd",
-                    "data": "0x734e7fb90000000000000000000000000000000000000000000000000000000064d40c600000000000000000000000000000000000000000000000000000000064d43690",  # noqa: E501
-                },
-                "latest",
-            ],
+            params=self._erc20_eth_call_params_factory(get_rng()),
         ),
 
     @task(24)

--- a/chainbench/profile/evm/debug_trace.py
+++ b/chainbench/profile/evm/debug_trace.py
@@ -16,7 +16,7 @@ class EVMDebugTraceProfile(EVMBenchUser):
         self.make_call(
             name="debug_trace_transaction",
             method="debug_traceTransaction",
-            params=self._trace_transaction_params_factory(get_rng()),
+            params=self._debug_trace_transaction_params_factory(get_rng()),
         ),
 
     @task(41)
@@ -24,7 +24,7 @@ class EVMDebugTraceProfile(EVMBenchUser):
         self.make_call(
             name="debug_trace_call",
             method="debug_traceCall",
-            params=self._trace_call_params_factory(get_rng()),
+            params=self._debug_trace_call_params_factory(get_rng()),
         ),
 
     @task(36)
@@ -32,7 +32,7 @@ class EVMDebugTraceProfile(EVMBenchUser):
         self.make_call(
             name="debug_trace_block_by_number",
             method="debug_traceBlockByNumber",
-            params=self._trace_block_by_number_params_factory(),
+            params=self._debug_trace_block_by_number_params_factory(),
         ),
 
     @task(1)
@@ -40,5 +40,5 @@ class EVMDebugTraceProfile(EVMBenchUser):
         self.make_call(
             name="debug_trace_block_by_hash",
             method="debug_traceBlockByHash",
-            params=self._trace_block_by_hash_params_factory(get_rng()),
+            params=self._debug_trace_block_by_hash_params_factory(get_rng()),
         ),

--- a/chainbench/profile/evm/debug_trace.py
+++ b/chainbench/profile/evm/debug_trace.py
@@ -32,7 +32,7 @@ class EVMDebugTraceProfile(EVMBenchUser):
         self.make_call(
             name="debug_trace_block_by_number",
             method="debug_traceBlockByNumber",
-            params=self._trace_block_by_number_params_factory(get_rng()),
+            params=self._trace_block_by_number_params_factory(),
         ),
 
     @task(1)

--- a/chainbench/profile/evm/heavy.py
+++ b/chainbench/profile/evm/heavy.py
@@ -17,7 +17,7 @@ class EVMHeavyProfile(EVMBenchUser):
         self.make_call(
             name="debug_trace_transaction",
             method="debug_traceTransaction",
-            params=self._trace_transaction_params_factory(get_rng()),
+            params=self._debug_trace_transaction_params_factory(get_rng()),
         ),
 
     @task
@@ -121,7 +121,7 @@ class EVMHeavyProfile(EVMBenchUser):
         self.make_call(
             name="debug_trace_block_by_number",
             method="debug_traceBlockByNumber",
-            params=self._trace_block_by_number_params_factory(),
+            params=self._debug_trace_block_by_number_params_factory(),
         )
 
     @task
@@ -129,7 +129,7 @@ class EVMHeavyProfile(EVMBenchUser):
         self.make_call(
             name="debug_trace_block_by_hash",
             method="debug_traceBlockByHash",
-            params=self._trace_block_by_hash_params_factory(get_rng()),
+            params=self._debug_trace_block_by_hash_params_factory(get_rng()),
         )
 
     @task

--- a/chainbench/profile/evm/heavy.py
+++ b/chainbench/profile/evm/heavy.py
@@ -121,7 +121,7 @@ class EVMHeavyProfile(EVMBenchUser):
         self.make_call(
             name="debug_trace_block_by_number",
             method="debug_traceBlockByNumber",
-            params=self._trace_block_by_number_params_factory(get_rng()),
+            params=self._trace_block_by_number_params_factory(),
         )
 
     @task

--- a/chainbench/profile/evm/heavy.py
+++ b/chainbench/profile/evm/heavy.py
@@ -25,7 +25,7 @@ class EVMHeavyProfile(EVMBenchUser):
         self.make_call(
             name="trace_block",
             method="trace_block",
-            params=self._block_params_factory(get_rng()),
+            params=self._block_params_factory(),
         ),
 
     @tag("get-logs")

--- a/chainbench/profile/evm/heavy.py
+++ b/chainbench/profile/evm/heavy.py
@@ -58,7 +58,7 @@ class EVMHeavyProfile(EVMBenchUser):
         self.make_call(
             name="trace_replay_block_transactions",
             method="trace_replayBlockTransactions",
-            params=self._trace_replay_block_transaction_params_factory(get_rng()),
+            params=self._trace_replay_block_transaction_params_factory(),
         )
 
     @task
@@ -137,5 +137,5 @@ class EVMHeavyProfile(EVMBenchUser):
         self.make_call(
             name="eth_estimate_gas",
             method="eth_estimateGas",
-            params=self._eth_estimate_gas_params_factory(get_rng()),
+            params=self._erc20_eth_call_params_factory(get_rng()),
         )

--- a/chainbench/profile/evm/light.py
+++ b/chainbench/profile/evm/light.py
@@ -45,7 +45,7 @@ class EVMLightProfile(EVMBenchUser):
         self.make_call(
             name="get_block_by_number",
             method="eth_getBlockByNumber",
-            params=self._block_params_factory(get_rng()),
+            params=self._block_params_factory(),
         ),
 
     @task

--- a/chainbench/profile/oasis/general.py
+++ b/chainbench/profile/oasis/general.py
@@ -5,14 +5,14 @@ from chainbench.util.rng import get_rng
 
 
 class OasisProfile(EVMBenchUser):
-    wait_time = constant_pacing(2)
+    wait_time = constant_pacing(1)
 
     @task
     def get_block_by_number_task(self):
         self.make_call(
             name="get_block_by_number",
             method="eth_getBlockByNumber",
-            params=self._block_params_factory(get_rng()),
+            params=self._block_params_factory(),
         ),
 
     @task

--- a/chainbench/profile/polygon/general.py
+++ b/chainbench/profile/polygon/general.py
@@ -25,7 +25,7 @@ from chainbench.util.rng import get_rng
 
 
 class PolygonGeneral(EVMBenchUser):
-    wait_time = constant_pacing(2)
+    wait_time = constant_pacing(1)
     weight = 19
 
     @task(100)
@@ -62,7 +62,7 @@ class PolygonGeneral(EVMBenchUser):
         self.make_call(
             name="get_block_by_number",
             method="eth_getBlockByNumber",
-            params=self._block_params_factory(get_rng()),
+            params=self._block_params_factory(),
         ),
 
     @task(16)
@@ -94,7 +94,7 @@ class PolygonGeneral(EVMBenchUser):
         self.make_call(
             name="block",
             method="trace_block",
-            params=self._block_params_factory(get_rng()),
+            params=self._block_params_factory(),
         ),
 
 

--- a/chainbench/profile/solana/general.py
+++ b/chainbench/profile/solana/general.py
@@ -23,7 +23,7 @@ from chainbench.util.rng import get_rng
 
 
 class SolanaProfile(SolanaBenchUser):
-    wait_time = constant_pacing(2)
+    wait_time = constant_pacing(1)
 
     @task(1000)
     def get_account_info_task(self):

--- a/chainbench/profile/starknet/wallet.py
+++ b/chainbench/profile/starknet/wallet.py
@@ -19,7 +19,7 @@ from chainbench.util.rng import get_rng
 
 
 class StarkNetWalletProfile(StarkNetBenchUser):
-    wait_time = constant_pacing(2)
+    wait_time = constant_pacing(1)
 
     @task(435)
     def call_task(self):

--- a/chainbench/test_data/base.py
+++ b/chainbench/test_data/base.py
@@ -21,6 +21,7 @@ Block = dict[str, t.Any]
 BlockNumber = int
 BlockHash = str
 Blocks = list[tuple[BlockNumber, BlockHash]]
+ChainId = int
 
 
 @dataclass(frozen=True)
@@ -72,11 +73,6 @@ class BlockchainData:
         self.accounts = data["accounts"]
 
 
-class ChainInfo(t.TypedDict):
-    name: str
-    start_block: BlockNumber
-
-
 class BaseTestData:
     DEFAULT_SIZE = "S"
 
@@ -93,10 +89,12 @@ class BaseTestData:
 
         self._data: BlockchainData | None = None
 
-    def update(self, host_url: str, parsed_options: Namespace) -> None:
-        self._logger.info("Updating data")
+    def set_host(self, host_url: str):
         self._host = host_url
         self._logger.debug("Host: %s", self._host)
+
+    def update(self, parsed_options: Namespace):
+        self._logger.info("Updating data")
         self._data = self._get_init_data_from_blockchain(parsed_options)
         self._logger.info("Data fetched")
         self._logger.debug("Data: %s", self._data)

--- a/chainbench/test_data/blockchain/evm.py
+++ b/chainbench/test_data/blockchain/evm.py
@@ -6,35 +6,23 @@ from chainbench.util.rng import RNG
 
 
 class SmartContract:
-    def __init__(self, address: str, function_params: list[t.Callable]):
+    def __init__(self, address: str):
         self.address = address
-        self.function_params = function_params
 
 
 class ERC20Contract(SmartContract):
-    def __init__(self, address: str):
-        function_params = [
-            self.total_supply_params,
-            self.symbol_params,
-            self.balance_of_params,
-            self.name_params,
-        ]
-        super().__init__(address, function_params)
-
-    def total_supply_params(self, **kwargs) -> dict[str, str]:
+    def total_supply_params(self) -> dict[str, str]:
         return {"data": "0x18160ddd", "to": self.address}
 
-    def balance_of_params(self, **kwargs) -> dict[str, str]:
-        return {"data": "0x70a08231" + kwargs["address"][2:].zfill(64), "to": self.address}
+    def balance_of_params(self, target_address: str) -> dict[str, str]:
+        return {"data": "0x70a08231" + target_address[2:].zfill(64), "to": self.address}
 
-    def symbol_params(self, **kwargs) -> dict[str, str]:
+    def symbol_params(self) -> dict[str, str]:
         return {"data": "0x95d89b41", "to": self.address}
 
-    def name_params(self, **kwargs) -> dict[str, str]:
+    def name_params(self) -> dict[str, str]:
         return {"data": "0x06fdde03", "to": self.address}
 
-    def get_random_function_params(self, rng: RNG) -> t.Callable:
-        return rng.random.choice(self.function_params)
 
 class NetworkInfo(t.TypedDict):
     name: str

--- a/chainbench/test_data/blockchain/evm.py
+++ b/chainbench/test_data/blockchain/evm.py
@@ -2,6 +2,7 @@ import typing as t
 from typing import Mapping
 
 from chainbench.test_data.base import BlockNumber
+from chainbench.util.rng import RNG
 
 
 class SmartContract:
@@ -32,6 +33,8 @@ class ERC20Contract(SmartContract):
     def name_params(self, **kwargs) -> dict[str, str]:
         return {"data": "0x06fdde03", "to": self.address}
 
+    def get_random_function_params(self, rng: RNG) -> t.Callable:
+        return rng.random.choice(self.function_params)
 
 class NetworkInfo(t.TypedDict):
     name: str
@@ -63,6 +66,9 @@ class ChainInfo:
 
     def get_contracts(self) -> list[ERC20Contract]:
         return [ERC20Contract(address) for address in self.contract_addresses]
+
+    def get_random_contract(self, rng: RNG) -> ERC20Contract:
+        return rng.random.choice(self.get_contracts())
 
     DATA: Mapping[int, NetworkInfo] = {
         1: {

--- a/chainbench/test_data/blockchain/evm.py
+++ b/chainbench/test_data/blockchain/evm.py
@@ -1,0 +1,171 @@
+import typing as t
+from typing import Mapping
+
+from chainbench.test_data.base import BlockNumber
+
+
+class SmartContract:
+    def __init__(self, address: str, function_params: list[t.Callable]):
+        self.address = address
+        self.function_params = function_params
+
+
+class ERC20Contract(SmartContract):
+    def __init__(self, address: str):
+        function_params = [
+            self.total_supply_params,
+            self.symbol_params,
+            self.balance_of_params,
+            self.name_params,
+        ]
+        super().__init__(address, function_params)
+
+    def total_supply_params(self, **kwargs) -> dict[str, str]:
+        return {"data": "0x18160ddd", "to": self.address}
+
+    def balance_of_params(self, **kwargs) -> dict[str, str]:
+        return {"data": "0x70a08231" + kwargs["address"][2:].zfill(64), "to": self.address}
+
+    def symbol_params(self, **kwargs) -> dict[str, str]:
+        return {"data": "0x95d89b41", "to": self.address}
+
+    def name_params(self, **kwargs) -> dict[str, str]:
+        return {"data": "0x06fdde03", "to": self.address}
+
+
+class NetworkInfo(t.TypedDict):
+    name: str
+    start_block: BlockNumber
+    contract_addresses: list[str]
+
+
+class ChainInfo:
+    def __new__(cls, chain_id: int):
+        if chain_id not in cls.DATA:
+            raise ValueError(f"Unsupported chain id: {chain_id}")
+        instance = super().__new__(cls)
+        return instance
+
+    def __init__(self, chain_id: int):
+        self.chain_id = chain_id
+
+    @property
+    def name(self) -> str:
+        return self.DATA[self.chain_id]["name"]
+
+    @property
+    def start_block(self) -> BlockNumber:
+        return self.DATA[self.chain_id]["start_block"]
+
+    @property
+    def contract_addresses(self) -> list[str]:
+        return self.DATA[self.chain_id]["contract_addresses"]
+
+    def get_contracts(self) -> list[ERC20Contract]:
+        return [ERC20Contract(address) for address in self.contract_addresses]
+
+    DATA: Mapping[int, NetworkInfo] = {
+        1: {
+            "name": "ethereum-mainnet",
+            "start_block": 10000000,
+            "contract_addresses": [
+                "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                "0xB8c77482e45F1F44dE1745F52C74426C631bDD52",
+                "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+                "0x514910771AF9Ca656af840dff83E8264EcF986CA",
+                "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+                "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE",
+                "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
+                "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+                "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+            ],
+        },
+        56: {
+            "name": "bsc-mainnet",
+            "start_block": 20000000,
+            "contract_addresses": [
+                "0x2170Ed0880ac9A755fd29B2688956BD959F933F8",
+                "0x55d398326f99059fF775485246999027B3197955",
+                "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+                "0x1D2F0da169ceB9fC7B3144628dB156f3F6c60dBE",
+                "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d",
+                "0x3EE2200Efb3400fAbB9AacF31297cBdD1d435D47",
+                "0x1CE0c2827e2eF14D5C4f29a091d735A204794041",
+                "0xbA2aE424d960c26247Dd6c32edC70B295c744C43",
+                "0x7083609fCE4d1d8Dc0C979AAb8c869Ea2C873402",
+                "0xF8A0BF9cF54Bb92F17374d9e9A321E6a111a51bD",
+            ],
+        },
+        137: {
+            "name": "polygon-mainnet",
+            "start_block": 35000000,
+            "contract_addresses": [
+                "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+                "0xc2132D05D31c914a87C6611C10748AEb04B58e8F",
+                "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+                "0x2C89bbc92BD86F8075d1DEcc58C7F4E0107f286b",
+                "0x53E0bca35eC356BD5ddDFebbD1Fc0fD03FaBad39",
+                "0x0000000000000000000000000000000000001010",
+                "0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6",
+                "0x6f8a06447Ff6FcF75d803135a7de15CE88C1d4ec",
+                "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
+                "0xb33EaAd8d922B1083446DC23f610c2567fB5180f",
+            ],
+        },
+        23294: {
+            "name": "oasis-sapphire-mainnet",
+            "start_block": 0,
+            "contract_addresses": [
+                "0x39d22B78A7651A76Ffbde2aaAB5FD92666Aca520",
+                "0x8Bc2B030b299964eEfb5e1e0b36991352E56D2D3",
+                "0x6b59C68405B0216C2C8ba1EC1f8DCcBd47892c58",
+                "0xda4ff51d969aC5982F7eA284c27E8Ed6b8BD1a7c",
+                "0xE48151964556381B33f93E05E36381Fd53Ec053E",
+                "0xa349005a68FA33e8DACAAa850c45175bbcD49B19",
+            ],
+        },
+        43114: {
+            "name": "avalanche-mainnet",
+            "start_block": 20000000,
+            "contract_addresses": [
+                "0x63a72806098Bd3D9520cC43356dD78afe5D386D9",
+                "0x5947BB275c521040051D82396192181b413227A3",
+                "0xc7198437980c041c805A1EDcbA50c1Ce5db95118",
+                "0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB",
+                "0xA7D7079b0FEaD91F3e65f86E8915Cb59c1a4C664",
+                "0xFE6B19286885a4F7F55AdAD09C3Cd1f906D2478F",
+                "0x2147EFFF675e4A4eE1C2f918d181cDBd7a8E208f",
+                "0x39cf1BD5f15fb22eC3D9Ff86b0727aFc203427cc",
+                "0x19860CCB0A68fd4213aB9D8266F7bBf05A8dDe98",
+                "0x8a0cAc13c7da965a312f08ea4229c37869e85cB9",
+            ],
+        },
+        8453: {
+            "name": "base-mainnet",
+            "start_block": 1,
+            "contract_addresses": [
+                "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb",
+                "0x2Ae3F1Ec7F1F5012CFEab0185bfc7aa3cf0DEc22",
+                "0x4A3A6Dd60A34bB2Aba60D73B4C88315E9CeB6A3D",
+                "0x703D57164CA270b0B330A87FD159CfEF1490c0a5",
+                "0x09188484e1Ab980DAeF53a9755241D759C5B7d60",
+                "0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA",
+                "0x4200000000000000000000000000000000000006",
+                "0xE3B53AF74a4BF62Ae5511055290838050bf764Df",
+                "0x78a087d713Be963Bf307b18F2Ff8122EF9A63ae9",
+            ],
+        },
+        84531: {
+            "name": "base-goerli-testnet",
+            "start_block": 1,
+            "contract_addresses": [
+                "0x231401dC8b53338d78c08f83CC4EBc74148196d0",
+                "0xF175520C52418dfE19C8098071a252da48Cd1C19",
+                "0x4B2d9827F7Ee26e8e1732b4614A35fBEa1f06D7A",
+                "0x41927EfAd7C649DB0605E53d7D409AEb2F499608",
+                "0xf0efcf5b2e7E8580d7D7aac0c11f5066541585D0",
+            ],
+        },
+    }

--- a/chainbench/test_data/evm.py
+++ b/chainbench/test_data/evm.py
@@ -13,7 +13,8 @@ from chainbench.test_data.base import (
     Tx,
     TxHash,
 )
-from chainbench.test_data.blockchain.evm import ChainInfo
+from chainbench.test_data.blockchain.evm import ChainInfo, ERC20Contract
+from chainbench.util.rng import RNG
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +26,12 @@ class EVMTestData(BaseTestData):
 
     def set_chain_info(self, chain_id: ChainId):
         self.chain_info = ChainInfo(chain_id)
+
+    def get_random_erc20_contract(self, rng: RNG) -> ERC20Contract:
+        if self.chain_info is None:
+            raise ValueError("Chain info is not set")
+        else:
+            return self.chain_info.get_random_contract(rng)
 
     def fetch_chain_id(self) -> int:
         return self._parse_hex_to_int(self._make_call("eth_chainId"))

--- a/chainbench/test_data/starknet.py
+++ b/chainbench/test_data/starknet.py
@@ -1,4 +1,5 @@
 import logging
+import typing as t
 from typing import Mapping
 
 from chainbench.test_data import EVMTestData
@@ -8,12 +9,16 @@ from chainbench.test_data.base import (
     BlockchainDataSize,
     BlockHash,
     BlockNumber,
-    ChainInfo,
     Tx,
     TxHash,
 )
 
 logger = logging.getLogger(__name__)
+
+
+class ChainInfo(t.TypedDict):
+    name: str
+    start_block: BlockNumber
 
 
 class StarkNetTestData(EVMTestData):
@@ -33,7 +38,7 @@ class StarkNetTestData(EVMTestData):
         # },
     }
 
-    def _fetch_chain_id(self) -> int:
+    def fetch_chain_id(self) -> int:
         return self._parse_hex_to_int(self._make_call("starknet_chainId"))
 
     def _fetch_latest_block_number(self) -> BlockNumber:

--- a/chainbench/user/evm.py
+++ b/chainbench/user/evm.py
@@ -67,7 +67,7 @@ class EVMBenchUser(BaseBenchUser):
             {"tracer": "callTracer", "timeout": self._default_trace_timeout},
         ]
 
-    def _trace_block_by_number_params_factory(self, rng: RNG) -> list[str | dict]:
+    def _trace_block_by_number_params_factory(self) -> list[str | dict]:
         return [
             "latest",
             {"tracer": "callTracer", "timeout": self._default_trace_timeout},
@@ -301,7 +301,7 @@ class EVMMethods(EVMBenchUser):
     def debug_trace_block_by_number_task(self) -> None:
         self.make_call(
             method="debug_traceBlockByNumber",
-            params=self._trace_block_by_number_params_factory(self.rng.get_rng()),
+            params=self._trace_block_by_number_params_factory(),
         )
 
     def debug_trace_call_task(self) -> None:

--- a/chainbench/user/evm.py
+++ b/chainbench/user/evm.py
@@ -40,7 +40,7 @@ class EVMBenchUser(BaseBenchUser):
             "latest",
         ]
 
-    def _trace_call_params_factory(self, rng: RNG) -> list[dict | BlockNumber]:
+    def _debug_trace_call_params_factory(self, rng: RNG) -> list[dict | BlockNumber]:
         tx_data = self.test_data.get_random_tx(rng)
         tx_param = {
             "to": tx_data["to"],
@@ -67,13 +67,13 @@ class EVMBenchUser(BaseBenchUser):
             {"tracer": "callTracer", "timeout": self._default_trace_timeout},
         ]
 
-    def _trace_block_by_number_params_factory(self) -> list[str | dict]:
+    def _debug_trace_block_by_number_params_factory(self) -> list[str | dict]:
         return [
             "latest",
             {"tracer": "callTracer", "timeout": self._default_trace_timeout},
         ]
 
-    def _trace_block_by_hash_params_factory(self, rng: RNG) -> list[BlockHash | dict]:
+    def _debug_trace_block_by_hash_params_factory(self, rng: RNG) -> list[BlockHash | dict]:
         return [
             self.test_data.get_random_block_hash(rng),
             {"tracer": "callTracer", "timeout": self._default_trace_timeout},
@@ -92,7 +92,7 @@ class EVMBenchUser(BaseBenchUser):
             ["vmTrace", "trace", "stateDiff"],
         ]
 
-    def _trace_transaction_params_factory(self, rng: RNG) -> list[TxHash | dict]:
+    def _debug_trace_transaction_params_factory(self, rng: RNG) -> list[TxHash | dict]:
         return [
             self.test_data.get_random_tx_hash(rng),
             {"tracer": "callTracer", "timeout": self._default_trace_timeout},
@@ -295,25 +295,25 @@ class EVMMethods(EVMBenchUser):
     def debug_trace_block_by_hash_task(self) -> None:
         self.make_call(
             method="debug_traceBlockByHash",
-            params=self._trace_block_by_hash_params_factory(self.rng.get_rng()),
+            params=self._debug_trace_block_by_hash_params_factory(self.rng.get_rng()),
         )
 
     def debug_trace_block_by_number_task(self) -> None:
         self.make_call(
             method="debug_traceBlockByNumber",
-            params=self._trace_block_by_number_params_factory(),
+            params=self._debug_trace_block_by_number_params_factory(),
         )
 
     def debug_trace_call_task(self) -> None:
         self.make_call(
             method="debug_traceCall",
-            params=self._trace_call_params_factory(self.rng.get_rng()),
+            params=self._debug_trace_call_params_factory(self.rng.get_rng()),
         )
 
     def debug_trace_transaction_task(self) -> None:
         self.make_call(
             method="debug_traceTransaction",
-            params=self._trace_transaction_params_factory(self.rng.get_rng()),
+            params=self._debug_trace_transaction_params_factory(self.rng.get_rng()),
         )
 
     def net_listening_task(self) -> None:
@@ -347,6 +347,12 @@ class EVMMethods(EVMBenchUser):
         self.make_call(
             method="trace_replayTransaction",
             params=self._trace_replay_transaction_params_factory(self.rng.get_rng()),
+        )
+
+    def trace_transaction_task(self) -> None:
+        self.make_call(
+            method="trace_transaction",
+            params=[self.test_data.get_random_tx_hash(self.rng.get_rng())],
         )
 
     def web3_client_version_task(self) -> None:

--- a/docs/PROFILE.md
+++ b/docs/PROFILE.md
@@ -64,7 +64,7 @@ class OasisProfile(EVMBenchUser):
         self.make_call(
             name="get_block_by_number",
             method="eth_getBlockByNumber",
-            params=self._block_params_factory(get_rng()),
+            params=self._block_params_factory(),
         ),
 ```
 
@@ -93,7 +93,7 @@ class OasisProfile(EVMBenchUser):
         self.make_call(
             name="get_block_by_number",
             method="eth_getBlockByNumber",
-            params=self._block_params_factory(get_rng()),
+            params=self._block_params_factory(),
         ),
 
     @task
@@ -148,7 +148,7 @@ class OasisProfile(EVMBenchUser):
         self.make_call(
             name="get_block_by_number",
             method="eth_getBlockByNumber",
-            params=self._block_params_factory(get_rng()),
+            params=self._block_params_factory(),
         ),
 
     @task
@@ -186,7 +186,7 @@ class OasisProfile(EVMBenchUser):
         self.make_call(
             name="get_block_by_number",
             method="eth_getBlockByNumber",
-            params=self._block_params_factory(get_rng()),
+            params=self._block_params_factory(),
         ),
 
     @task
@@ -248,7 +248,7 @@ class OasisProfile(EVMBenchUser):
         self.make_call(
             name="get_block_by_number",
             method="eth_getBlockByNumber",
-            params=self._block_params_factory(get_rng()),
+            params=self._block_params_factory(),
         ),
 
     @task


### PR DESCRIPTION
## Description
- implement dynamic eth_call params for evm protocols utilizing erc20 token methods
- added data on top 5 to 10 contract addresses for supported evm networks
- changed number of blocks for --use-recent-blocks to 128 latest blocks
- use latest whenever possible to avoid errors when testing full nodes that perform pruning
- minor refactoring on cli messages to have a better overview of test data initialization
- refactoring to clean up main cli logic
- fixed eth_estimateGas by reusing new dynamic eth_call params
- add eth_get_code_task

## Issues Resolved
- eth_estimateGas occasionally returning errors like "execution reverted"
- errors when testing full nodes that perform pruning due to requesting data from pruned blocks
