### PR TITLE
add support for Ethereum Consensus API

### DIFF
--- a/chainbench/main.py
+++ b/chainbench/main.py
@@ -12,7 +12,7 @@ from click import Context, Parameter
 from locust import runners
 
 from chainbench.tools.discovery.rpc import DiscoveryResult
-from chainbench.user import EVMMethods
+from chainbench.user import EvmMethods
 from chainbench.util.cli import (
     ContextData,
     ensure_results_dir,
@@ -53,7 +53,7 @@ def cli(ctx: Context):
 
 def validate_method(ctx: Context, param: Parameter, value: str) -> str:
     if value is not None:
-        method_list = [task_to_method(task) for task in get_subclass_methods(EVMMethods)]
+        method_list = [task_to_method(task) for task in get_subclass_methods(EvmMethods)]
         if value not in method_list:
             raise click.BadParameter(
                 f"Method {value} is not supported. " f"Use 'chainbench list methods' to list all available methods."
@@ -472,7 +472,7 @@ def profiles(profile_dir: Path) -> None:
     help="Lists all available evm methods.",
 )
 def methods() -> None:
-    task_list = get_subclass_methods(EVMMethods)
+    task_list = get_subclass_methods(EvmMethods)
     for task in task_list:
         click.echo(task_to_method(task))
 

--- a/chainbench/main.py
+++ b/chainbench/main.py
@@ -386,12 +386,12 @@ def start(
 
 
 def validate_clients(ctx: Context, param: Parameter, value: str) -> list[str]:
-    from chainbench.tools.discovery.rpc import RPCDiscovery
+    from chainbench.tools.discovery.rpc import RpcDiscovery
 
     if value is not None:
         input_client_list = value.split(",")
         client_list: list[str] = []
-        for client in RPCDiscovery.get_clients():
+        for client in RpcDiscovery.get_clients():
             client_list.extend(client.get_cli_argument_names())
         for client_name in input_client_list:
             if client_name not in client_list:
@@ -423,9 +423,9 @@ def discover(endpoint: str | None, clients: list[str]) -> None:
         click.echo("Target endpoint is required.")
         sys.exit(1)
 
-    from chainbench.tools.discovery.rpc import RPCDiscovery
+    from chainbench.tools.discovery.rpc import RpcDiscovery
 
-    rpc_discovery = RPCDiscovery(endpoint, clients)
+    rpc_discovery = RpcDiscovery(endpoint, clients)
     click.echo(f"Please wait, discovering methods available on {endpoint}...")
 
     def get_discovery_result(method: str) -> None:
@@ -445,9 +445,9 @@ def _list() -> None:
     help="Lists all available client options for method discovery.",
 )
 def clients() -> None:
-    from chainbench.tools.discovery.rpc import RPCDiscovery
+    from chainbench.tools.discovery.rpc import RpcDiscovery
 
-    for client in RPCDiscovery.get_clients():
+    for client in RpcDiscovery.get_clients():
         for unique_client in client.get_name_and_version():
             click.echo(unique_client)
 

--- a/chainbench/profile/avalanche/general.py
+++ b/chainbench/profile/avalanche/general.py
@@ -17,11 +17,11 @@ pie title Methods Distribution
 """
 from locust import constant_pacing, tag, task
 
-from chainbench.user import EVMUser
+from chainbench.user import EvmUser
 from chainbench.util.rng import get_rng
 
 
-class AvalancheProfile(EVMUser):
+class AvalancheProfile(EvmUser):
     wait_time = constant_pacing(1)
     weight = 91
 
@@ -129,7 +129,7 @@ class AvalancheProfile(EVMUser):
         ),
 
 
-class AvalancheGetLogsProfile(EVMUser):
+class AvalancheGetLogsProfile(EvmUser):
     wait_time = constant_pacing(10)
     weight = 9
 

--- a/chainbench/profile/avalanche/general.py
+++ b/chainbench/profile/avalanche/general.py
@@ -27,7 +27,7 @@ class AvalancheProfile(EvmUser):
 
     @task(100)
     def call_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="call",
             method="eth_call",
             params=[
@@ -41,7 +41,7 @@ class AvalancheProfile(EvmUser):
 
     @task(50)
     def get_block_by_number_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_block_by_number",
             method="eth_getBlockByNumber",
             params=self._block_params_factory(),
@@ -49,7 +49,7 @@ class AvalancheProfile(EvmUser):
 
     @task(17)
     def get_transaction_receipt_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_transaction_receipt",
             method="eth_getTransactionReceipt",
             params=self._transaction_by_hash_params_factory(get_rng()),
@@ -57,21 +57,21 @@ class AvalancheProfile(EvmUser):
 
     @task(15)
     def chain_id_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="chain_id",
             method="eth_chainId",
         ),
 
     @task(15)
     def block_number_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="block_number",
             method="eth_blockNumber",
         ),
 
     @task(11)
     def get_balance_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_balance",
             method="eth_getBalance",
             params=self._get_account_and_block_number_params_factory_latest(get_rng()),
@@ -79,7 +79,7 @@ class AvalancheProfile(EvmUser):
 
     @task(10)
     def get_transaction_by_hash_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_transaction_by_hash",
             method="eth_getTransactionByHash",
             params=self._transaction_by_hash_params_factory(get_rng()),
@@ -87,7 +87,7 @@ class AvalancheProfile(EvmUser):
 
     @task(5)
     def estimate_gas_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="estimate_gas",
             method="eth_estimateGas",
             params=[
@@ -101,14 +101,14 @@ class AvalancheProfile(EvmUser):
 
     @task(4)
     def client_version_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="client_version",
             method="web3_clientVersion",
         ),
 
     @task(3)
     def get_block_by_hash_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_block_by_hash",
             method="eth_getBlockByHash",
             params=self._block_by_hash_params_factory(get_rng()),
@@ -116,14 +116,14 @@ class AvalancheProfile(EvmUser):
 
     @task(3)
     def gas_price_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="gas_price",
             method="eth_gasPrice",
         ),
 
     @task(3)
     def max_priority_fee_per_gas_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="max_priority_fee_per_gas",
             method="eth_maxPriorityFeePerGas",
         ),
@@ -136,7 +136,7 @@ class AvalancheGetLogsProfile(EvmUser):
     @tag("get-logs")
     @task
     def get_logs_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_logs",
             method="eth_getLogs",
             params=self._get_logs_params_factory(get_rng()),

--- a/chainbench/profile/bsc/general.py
+++ b/chainbench/profile/bsc/general.py
@@ -26,7 +26,7 @@ class BscProfile(EvmUser):
 
     @task(100)
     def call_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="call",
             method="eth_call",
             params=[
@@ -40,7 +40,7 @@ class BscProfile(EvmUser):
 
     @task(93)
     def get_transaction_receipt_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_transaction_receipt",
             method="eth_getTransactionReceipt",
             params=self._transaction_by_hash_params_factory(get_rng()),
@@ -48,21 +48,21 @@ class BscProfile(EvmUser):
 
     @task(28)
     def block_number_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="block_number",
             method="eth_blockNumber",
         ),
 
     @task(18)
     def chain_id_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="chain_id",
             method="eth_chainId",
         ),
 
     @task(13)
     def get_block_by_number_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_block_by_number",
             method="eth_getBlockByNumber",
             params=self._block_params_factory(),
@@ -70,7 +70,7 @@ class BscProfile(EvmUser):
 
     @task(9)
     def get_transaction_by_hash_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_transaction_by_hash",
             method="eth_getTransactionByHash",
             params=self._transaction_by_hash_params_factory(get_rng()),
@@ -78,7 +78,7 @@ class BscProfile(EvmUser):
 
     @task(5)
     def get_balance_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_balance",
             method="eth_getBalance",
             params=self._get_account_and_block_number_params_factory_latest(get_rng()),
@@ -86,7 +86,7 @@ class BscProfile(EvmUser):
 
     @task(3)
     def get_block_by_hash_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_block_by_hash",
             method="eth_getBlockByHash",
             params=self._block_by_hash_params_factory(get_rng()),
@@ -100,7 +100,7 @@ class BscGetLogsProfile(EvmUser):
     @tag("get-logs")
     @task
     def get_logs_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_logs",
             method="eth_getLogs",
             params=self._get_logs_params_factory(get_rng()),

--- a/chainbench/profile/bsc/general.py
+++ b/chainbench/profile/bsc/general.py
@@ -16,11 +16,11 @@ pie title Methods Distribution
 """
 from locust import constant_pacing, tag, task
 
-from chainbench.user import EVMUser
+from chainbench.user import EvmUser
 from chainbench.util.rng import get_rng
 
 
-class BscProfile(EVMUser):
+class BscProfile(EvmUser):
     wait_time = constant_pacing(1)
     weight = 89
 
@@ -93,7 +93,7 @@ class BscProfile(EVMUser):
         ),
 
 
-class BscGetLogsProfile(EVMUser):
+class BscGetLogsProfile(EvmUser):
     wait_time = constant_pacing(10)
     weight = 12
 

--- a/chainbench/profile/ethereum/consensus.py
+++ b/chainbench/profile/ethereum/consensus.py
@@ -5,6 +5,8 @@ from locust import constant_pacing
 
 from chainbench.user.ethereum import EthConsensusMethods
 
+# mypy: ignore_errors
+
 
 class EthereumConsensusProfile(EthConsensusMethods):
     wait_time = constant_pacing(1)

--- a/chainbench/profile/ethereum/consensus.py
+++ b/chainbench/profile/ethereum/consensus.py
@@ -1,0 +1,25 @@
+"""
+Ethereum Consensus profile.
+"""
+from locust import constant_pacing
+
+from chainbench.user.ethereum import EthConsensusMethods
+
+
+class EthereumConsensusProfile(EthConsensusMethods):
+    wait_time = constant_pacing(1)
+    tasks = {
+        EthConsensusMethods.eth_v1_beacon_states_validators_random_ids_task: 698,
+        EthConsensusMethods.eth_v1_beacon_states_validators_head_task: 23,
+        EthConsensusMethods.eth_v1_beacon_states_head_committees_random_epoch_task: 10,
+        EthConsensusMethods.eth_v1_beacon_states_validators_random_validator_status_task: 10,
+        EthConsensusMethods.eth_v1_beacon_states_random_state_id_finality_checkpoints_task: 10,
+        EthConsensusMethods.eth_v2_beacon_blocks_random_block_id_task: 8,
+        EthConsensusMethods.eth_v2_beacon_blocks_head_task: 6,
+        EthConsensusMethods.eth_v1_beacon_headers_head_task: 4,
+        EthConsensusMethods.eth_v1_config_spec_task: 3,
+        EthConsensusMethods.eth_v1_node_health_task: 2,
+        EthConsensusMethods.eth_v2_beacon_blocks_finalized_task: 1,
+        EthConsensusMethods.eth_v1_beacon_headers_random_block_id_task: 1,
+        EthConsensusMethods.eth_v1_node_version_task: 1,
+    }

--- a/chainbench/profile/ethereum/general.py
+++ b/chainbench/profile/ethereum/general.py
@@ -17,11 +17,11 @@ pie title Methods Distribution
 """
 from locust import constant_pacing, tag, task
 
-from chainbench.user import EVMUser
+from chainbench.user import EvmUser
 from chainbench.util.rng import get_rng
 
 
-class EthereumProfile(EVMUser):
+class EthereumProfile(EvmUser):
     wait_time = constant_pacing(1)
     weight = 487
 
@@ -95,7 +95,7 @@ class EthereumProfile(EVMUser):
         ),
 
 
-class EthGetLogsProfile(EVMUser):
+class EthGetLogsProfile(EvmUser):
     wait_time = constant_pacing(10)
     weight = 13
 

--- a/chainbench/profile/ethereum/general.py
+++ b/chainbench/profile/ethereum/general.py
@@ -27,7 +27,7 @@ class EthereumProfile(EvmUser):
 
     @task(100)
     def call_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="call",
             method="eth_call",
             params=self._erc20_eth_call_params_factory(get_rng()),
@@ -35,7 +35,7 @@ class EthereumProfile(EvmUser):
 
     @task(24)
     def get_transaction_receipt_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_transaction_receipt",
             method="eth_getTransactionReceipt",
             params=self._transaction_by_hash_params_factory(get_rng()),
@@ -43,14 +43,14 @@ class EthereumProfile(EvmUser):
 
     @task(19)
     def block_number_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="block_number",
             method="eth_blockNumber",
         ),
 
     @task(12)
     def get_balance_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_balance",
             method="eth_getBalance",
             params=self._get_account_and_block_number_params_factory_latest(get_rng()),
@@ -58,14 +58,14 @@ class EthereumProfile(EvmUser):
 
     @task(11)
     def chain_id_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="chain_id",
             method="eth_chainId",
         ),
 
     @task(9)
     def get_block_by_number_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_block_by_number",
             method="eth_getBlockByNumber",
             params=self._block_params_factory(),
@@ -73,7 +73,7 @@ class EthereumProfile(EvmUser):
 
     @task(8)
     def get_transaction_by_hash_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_transaction_by_hash",
             method="eth_getTransactionByHash",
             params=self._transaction_by_hash_params_factory(get_rng()),
@@ -82,14 +82,14 @@ class EthereumProfile(EvmUser):
     @tag("debug")
     @task(3)
     def trace_transaction_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="trace_transaction",
             method="debug_traceTransaction",
         ),
 
     @task(2)
     def client_version_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="client_version",
             method="web3_clientVersion",
         ),
@@ -102,7 +102,7 @@ class EthGetLogsProfile(EvmUser):
     @tag("get-logs")
     @task
     def get_logs_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_logs",
             method="eth_getLogs",
             params=self._get_logs_params_factory(get_rng()),

--- a/chainbench/profile/evm/all.py
+++ b/chainbench/profile/evm/all.py
@@ -4,10 +4,10 @@
 
 from locust import constant_pacing
 
-from chainbench.user import EVMMethods
+from chainbench.user import EvmMethods
 from chainbench.util.cli import get_subclass_methods
 
 
-class EVMAllProfile(EVMMethods):
+class EvmAllProfile(EvmMethods):
     wait_time = constant_pacing(1)
-    tasks = [EVMMethods.get_method(method) for method in get_subclass_methods(EVMMethods)]
+    tasks = [EvmMethods.get_method(method) for method in get_subclass_methods(EvmMethods)]

--- a/chainbench/profile/evm/debug_trace.py
+++ b/chainbench/profile/evm/debug_trace.py
@@ -13,7 +13,7 @@ class EvmDebugTraceProfile(EvmUser):
 
     @task(324)
     def debug_trace_transaction_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="debug_trace_transaction",
             method="debug_traceTransaction",
             params=self._debug_trace_transaction_params_factory(get_rng()),
@@ -21,7 +21,7 @@ class EvmDebugTraceProfile(EvmUser):
 
     @task(41)
     def debug_trace_call_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="debug_trace_call",
             method="debug_traceCall",
             params=self._debug_trace_call_params_factory(get_rng()),
@@ -29,7 +29,7 @@ class EvmDebugTraceProfile(EvmUser):
 
     @task(36)
     def debug_trace_block_by_number_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="debug_trace_block_by_number",
             method="debug_traceBlockByNumber",
             params=self._debug_trace_block_by_number_params_factory(),
@@ -37,7 +37,7 @@ class EvmDebugTraceProfile(EvmUser):
 
     @task(1)
     def debug_trace_block_by_hash_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="debug_trace_block_by_hash",
             method="debug_traceBlockByHash",
             params=self._debug_trace_block_by_hash_params_factory(get_rng()),

--- a/chainbench/profile/evm/debug_trace.py
+++ b/chainbench/profile/evm/debug_trace.py
@@ -4,11 +4,11 @@ EVM profile (debug_trace methods).
 
 from locust import constant_pacing, task
 
-from chainbench.user import EVMUser
+from chainbench.user import EvmUser
 from chainbench.util.rng import get_rng
 
 
-class EVMDebugTraceProfile(EVMUser):
+class EvmDebugTraceProfile(EvmUser):
     wait_time = constant_pacing(10)
 
     @task(324)

--- a/chainbench/profile/evm/get_logs.py
+++ b/chainbench/profile/evm/get_logs.py
@@ -13,7 +13,7 @@ class EvmGetLogsProfile(EvmUser):
 
     @task
     def get_logs_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_logs",
             method="eth_getLogs",
             params=self._get_logs_params_factory(get_rng()),

--- a/chainbench/profile/evm/get_logs.py
+++ b/chainbench/profile/evm/get_logs.py
@@ -4,11 +4,11 @@ EVM eth_getLogs profile.
 
 from locust import constant_pacing, task
 
-from chainbench.user import EVMUser
+from chainbench.user import EvmUser
 from chainbench.util.rng import get_rng
 
 
-class EVMGetLogsProfile(EVMUser):
+class EvmGetLogsProfile(EvmUser):
     wait_time = constant_pacing(10)
 
     @task

--- a/chainbench/profile/evm/heavy.py
+++ b/chainbench/profile/evm/heavy.py
@@ -5,11 +5,11 @@ from random import randint
 
 from locust import constant_pacing, tag, task
 
-from chainbench.user import EVMUser
+from chainbench.user import EvmUser
 from chainbench.util.rng import get_rng
 
 
-class EVMHeavyProfile(EVMUser):
+class EvmHeavyProfile(EvmUser):
     wait_time = constant_pacing(10)
 
     @task

--- a/chainbench/profile/evm/heavy.py
+++ b/chainbench/profile/evm/heavy.py
@@ -14,7 +14,7 @@ class EvmHeavyProfile(EvmUser):
 
     @task
     def debug_trace_transaction_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="debug_trace_transaction",
             method="debug_traceTransaction",
             params=self._debug_trace_transaction_params_factory(get_rng()),
@@ -22,7 +22,7 @@ class EvmHeavyProfile(EvmUser):
 
     @task
     def trace_block_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="trace_block",
             method="trace_block",
             params=self._block_params_factory(),
@@ -31,7 +31,7 @@ class EvmHeavyProfile(EvmUser):
     @tag("get-logs")
     @task
     def eth_get_logs_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="eth_get_logs",
             method="eth_getLogs",
             params=self._get_logs_params_factory(get_rng()),
@@ -39,7 +39,7 @@ class EvmHeavyProfile(EvmUser):
 
     @task
     def eth_get_blocks_receipts_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="eth_get_block_receipts",
             method="eth_getBlockReceipts",
             params=[hex(self.test_data.get_random_block_number(get_rng()))],
@@ -47,7 +47,7 @@ class EvmHeavyProfile(EvmUser):
 
     @task
     def trace_replay_transaction_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="trace_replay_transaction",
             method="trace_replayTransaction",
             params=self._trace_replay_transaction_params_factory(get_rng()),
@@ -55,7 +55,7 @@ class EvmHeavyProfile(EvmUser):
 
     @task
     def trace_replay_block_transactions_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="trace_replay_block_transactions",
             method="trace_replayBlockTransactions",
             params=self._trace_replay_block_transaction_params_factory(),
@@ -63,7 +63,7 @@ class EvmHeavyProfile(EvmUser):
 
     @task
     def trace_call_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="trace_call",
             method="trace_call",
             params=[
@@ -78,7 +78,7 @@ class EvmHeavyProfile(EvmUser):
 
     @task
     def trace_filter_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="trace_filter",
             method="trace_filter",
             params=self._trace_filter_params_factory(get_rng()),
@@ -86,7 +86,7 @@ class EvmHeavyProfile(EvmUser):
 
     @task
     def debug_trace_call_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="debug_trace_call",
             method="debug_traceCall",
             params=[
@@ -104,7 +104,7 @@ class EvmHeavyProfile(EvmUser):
 
     @task
     def debug_storage_range_at_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="debug_storage_range_at",
             method="debug_storageRangeAt",
             params=[
@@ -118,7 +118,7 @@ class EvmHeavyProfile(EvmUser):
 
     @task
     def debug_trace_block_by_number_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="debug_trace_block_by_number",
             method="debug_traceBlockByNumber",
             params=self._debug_trace_block_by_number_params_factory(),
@@ -126,7 +126,7 @@ class EvmHeavyProfile(EvmUser):
 
     @task
     def debug_trace_block_by_hash_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="debug_trace_block_by_hash",
             method="debug_traceBlockByHash",
             params=self._debug_trace_block_by_hash_params_factory(get_rng()),
@@ -134,7 +134,7 @@ class EvmHeavyProfile(EvmUser):
 
     @task
     def eth_estimate_gas_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="eth_estimate_gas",
             method="eth_estimateGas",
             params=self._erc20_eth_call_params_factory(get_rng()),

--- a/chainbench/profile/evm/light.py
+++ b/chainbench/profile/evm/light.py
@@ -3,11 +3,11 @@ EVM profile (light mode).
 """
 from locust import constant_pacing, task
 
-from chainbench.user import EVMUser
+from chainbench.user import EvmUser
 from chainbench.util.rng import get_rng
 
 
-class EVMLightProfile(EVMUser):
+class EvmLightProfile(EvmUser):
     wait_time = constant_pacing(1)
 
     @task

--- a/chainbench/profile/evm/light.py
+++ b/chainbench/profile/evm/light.py
@@ -12,7 +12,7 @@ class EvmLightProfile(EvmUser):
 
     @task
     def get_transaction_receipt_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_transaction_receipt",
             method="eth_getTransactionReceipt",
             params=self._transaction_by_hash_params_factory(get_rng()),
@@ -20,14 +20,14 @@ class EvmLightProfile(EvmUser):
 
     @task
     def block_number_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="block_number",
             method="eth_blockNumber",
         ),
 
     @task
     def get_balance_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_balance",
             method="eth_getBalance",
             params=self._get_account_and_block_number_params_factory_latest(get_rng()),
@@ -35,14 +35,14 @@ class EvmLightProfile(EvmUser):
 
     @task
     def chain_id_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="chain_id",
             method="eth_chainId",
         ),
 
     @task
     def get_block_by_number_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_block_by_number",
             method="eth_getBlockByNumber",
             params=self._block_params_factory(),
@@ -50,7 +50,7 @@ class EvmLightProfile(EvmUser):
 
     @task
     def get_transaction_by_hash_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_transaction_by_hash",
             method="eth_getTransactionByHash",
             params=self._transaction_by_hash_params_factory(get_rng()),
@@ -58,7 +58,7 @@ class EvmLightProfile(EvmUser):
 
     @task
     def client_version_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="client_version",
             method="web3_clientVersion",
         ),

--- a/chainbench/profile/oasis/general.py
+++ b/chainbench/profile/oasis/general.py
@@ -1,10 +1,10 @@
 from locust import constant_pacing, task
 
-from chainbench.user import EVMUser
+from chainbench.user import EvmUser
 from chainbench.util.rng import get_rng
 
 
-class OasisProfile(EVMUser):
+class OasisProfile(EvmUser):
     wait_time = constant_pacing(1)
 
     @task

--- a/chainbench/profile/oasis/general.py
+++ b/chainbench/profile/oasis/general.py
@@ -9,7 +9,7 @@ class OasisProfile(EvmUser):
 
     @task
     def get_block_by_number_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_block_by_number",
             method="eth_getBlockByNumber",
             params=self._block_params_factory(),
@@ -17,7 +17,7 @@ class OasisProfile(EvmUser):
 
     @task
     def get_balance_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_balance",
             method="eth_getBalance",
             params=self._get_balance_params_factory(get_rng()),
@@ -25,7 +25,7 @@ class OasisProfile(EvmUser):
 
     @task
     def get_transaction_count_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_transaction_count",
             method="eth_getTransactionCount",
             params=self._get_balance_params_factory(get_rng()),
@@ -33,7 +33,7 @@ class OasisProfile(EvmUser):
 
     @task
     def get_code_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_code",
             method="eth_getCode",
             params=self._get_balance_params_factory(get_rng()),
@@ -41,7 +41,7 @@ class OasisProfile(EvmUser):
 
     @task
     def get_transaction_by_hash_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_transaction_by_hash",
             method="eth_getTransactionByHash",
             params=self._transaction_by_hash_params_factory(get_rng()),
@@ -49,21 +49,21 @@ class OasisProfile(EvmUser):
 
     @task
     def get_block_number_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="block_number",
             method="eth_blockNumber",
         ),
 
     @task
     def get_syncing_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_syncing",
             method="eth_syncing",
         ),
 
     @task
     def get_block_transaction_count_by_number_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_block_transaction_count_by_number",
             method="eth_getBlockTransactionCountByNumber",
             params=self._random_block_number_params_factory(get_rng()),

--- a/chainbench/profile/polygon/general.py
+++ b/chainbench/profile/polygon/general.py
@@ -20,11 +20,11 @@ pie title Methods Distribution
 """
 from locust import constant_pacing, tag, task
 
-from chainbench.user import EVMUser
+from chainbench.user import EvmUser
 from chainbench.util.rng import get_rng
 
 
-class PolygonGeneral(EVMUser):
+class PolygonGeneral(EvmUser):
     wait_time = constant_pacing(1)
     weight = 19
 
@@ -98,7 +98,7 @@ class PolygonGeneral(EVMUser):
         ),
 
 
-class PolygonGetLogsProfile(EVMUser):
+class PolygonGetLogsProfile(EvmUser):
     wait_time = constant_pacing(10)
     weight = 1
 

--- a/chainbench/profile/polygon/general.py
+++ b/chainbench/profile/polygon/general.py
@@ -30,7 +30,7 @@ class PolygonGeneral(EvmUser):
 
     @task(100)
     def call_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="call",
             method="eth_call",
             params=[
@@ -44,7 +44,7 @@ class PolygonGeneral(EvmUser):
 
     @task(64)
     def get_transaction_receipt_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_transaction_receipt",
             method="eth_getTransactionReceipt",
             params=self._transaction_by_hash_params_factory(get_rng()),
@@ -52,14 +52,14 @@ class PolygonGeneral(EvmUser):
 
     @task(20)
     def chain_id_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="chain_id",
             method="eth_chainId",
         ),
 
     @task(17)
     def get_block_by_number_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_block_by_number",
             method="eth_getBlockByNumber",
             params=self._block_params_factory(),
@@ -67,14 +67,14 @@ class PolygonGeneral(EvmUser):
 
     @task(16)
     def block_number_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="block_number",
             method="eth_blockNumber",
         ),
 
     @task(11)
     def get_transaction_by_hash_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_transaction_by_hash",
             method="eth_getTransactionByHash",
             params=self._transaction_by_hash_params_factory(get_rng()),
@@ -82,7 +82,7 @@ class PolygonGeneral(EvmUser):
 
     @task(4)
     def get_balance_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_balance",
             method="eth_getBalance",
             params=self._get_account_and_block_number_params_factory_latest(get_rng()),
@@ -91,7 +91,7 @@ class PolygonGeneral(EvmUser):
     @tag("trace")
     @task(2)
     def block_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="block",
             method="trace_block",
             params=self._block_params_factory(),
@@ -105,7 +105,7 @@ class PolygonGetLogsProfile(EvmUser):
     @tag("get-logs")
     @task
     def get_logs_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_logs",
             method="eth_getLogs",
             params=self._get_logs_params_factory(get_rng()),

--- a/chainbench/profile/solana/general.py
+++ b/chainbench/profile/solana/general.py
@@ -27,75 +27,75 @@ class SolanaProfile(SolanaUser):
 
     @task(1000)
     def get_account_info_task(self):
-        self.make_call(
+        self.make_rpc_call(
             method="getAccountInfo",
             params=self._get_account_info_params_factory(get_rng()),
         ),
 
     @task(175)
     def get_block_task(self):
-        self.make_call(
+        self.make_rpc_call(
             method="getBlock",
             params=self._get_block_params_factory(get_rng()),
         ),
 
     @task(150)
     def get_token_accounts_by_owner(self):
-        self.make_call(
+        self.make_rpc_call(
             method="getTokenAccountsByOwner",
             params=self._get_token_accounts_by_owner_params_factory(get_rng()),
         ),
 
     @task(150)
     def get_multiple_accounts(self):
-        self.make_call(
+        self.make_rpc_call(
             method="getMultipleAccounts",
             params=self._get_multiple_accounts_params_factory(get_rng()),
         ),
 
     @task(130)
     def get_transaction(self):
-        self.make_call(
+        self.make_rpc_call(
             method="getTransaction",
             params=self._get_transaction_params_factory(get_rng()),
         ),
 
     @task(75)
     def get_signatures_for_address(self):
-        self.make_call(
+        self.make_rpc_call(
             method="getSignaturesForAddress",
             params=self._get_signatures_for_address_params_factory(get_rng()),
         ),
 
     @task(75)
     def get_latest_blockhash(self):
-        self.make_call(
+        self.make_rpc_call(
             method="getLatestBlockhash",
         ),
 
     @task(75)
     def get_balance(self):
-        self.make_call(
+        self.make_rpc_call(
             method="getBalance",
             params=self._get_balance_params_factory(get_rng()),
         ),
 
     @task(20)
     def get_slot(self):
-        self.make_call(
+        self.make_rpc_call(
             method="getSlot",
         ),
 
     @task(15)
     def get_block_height(self):
-        self.make_call(
+        self.make_rpc_call(
             method="getBlockHeight",
         ),
 
     @task(5)
     @tag("get-program-accounts")
     def get_program_accounts(self):
-        self.make_call(
+        self.make_rpc_call(
             method="getProgramAccounts",
             params=[
                 "SharkXwkS3h24fJ2LZvgG5tPbsH3BKQYuAtKdqskf1f",
@@ -105,33 +105,33 @@ class SolanaProfile(SolanaUser):
 
     @task(4)
     def get_signature_statuses(self):
-        self.make_call(
+        self.make_rpc_call(
             method="getSignatureStatuses",
             params=self._get_signature_statuses_params_factory(get_rng()),
         ),
 
     @task(3)
     def get_recent_blockhash(self):
-        self.make_call(
+        self.make_rpc_call(
             method="getRecentBlockhash",
         ),
 
     @task(2)
     def get_blocks(self):
-        self.make_call(
+        self.make_rpc_call(
             method="getBlocks",
             params=self._get_blocks_params_factory(get_rng()),
         ),
 
     @task(2)
     def get_epoch_info(self):
-        self.make_call(
+        self.make_rpc_call(
             method="getEpochInfo",
         ),
 
     @task(2)
     def get_confirmed_signatures_for_address2(self):
-        self.make_call(
+        self.make_rpc_call(
             method="getConfirmedSignaturesForAddress2",
             params=self._get_confirmed_signatures_for_address2_params_factory(get_rng()),
         ),

--- a/chainbench/profile/starknet/wallet.py
+++ b/chainbench/profile/starknet/wallet.py
@@ -23,18 +23,18 @@ class StarkNetWalletProfile(StarkNetUser):
 
     @task(435)
     def call_task(self):
-        self.make_call(name="call", method="starknet_call", params=self._call_params_factory(get_rng())),
+        self.make_rpc_call(name="call", method="starknet_call", params=self._call_params_factory(get_rng())),
 
     @task(200)
     def chain_id_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="chain_id",
             method="starknet_chainId",
         ),
 
     @task(133)
     def get_class_hash_at_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_class_hash_at",
             method="starknet_getClassHashAt",
             params=self._get_class_params_factory(get_rng()),
@@ -42,7 +42,7 @@ class StarkNetWalletProfile(StarkNetUser):
 
     @task(21)
     def get_transaction_receipt_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_transaction_receipt",
             method="starknet_getTransactionReceipt",
             params=self._get_tx_hash_params_factory(get_rng()),
@@ -50,7 +50,7 @@ class StarkNetWalletProfile(StarkNetUser):
 
     @task(3)
     def get_class_at_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_class_at",
             method="starknet_getClassAt",
             params=self._get_class_params_factory(get_rng()),
@@ -58,7 +58,7 @@ class StarkNetWalletProfile(StarkNetUser):
 
     @task(3)
     def get_nonce_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_nonce",
             method="starknet_getNonce",
             params=["latest", self._get_contract_address(get_rng())],
@@ -66,7 +66,7 @@ class StarkNetWalletProfile(StarkNetUser):
 
     @task(2)
     def simulate_transaction_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="simulate_transaction",
             method="starknet_simulateTransaction",
             params=self._simulate_transaction_params_factory(get_rng()),
@@ -75,7 +75,7 @@ class StarkNetWalletProfile(StarkNetUser):
 
     @task(1)
     def estimate_fee_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="estimate_fee",
             method="starknet_estimateFee",
             params=self._estimate_fee_params_factory(get_rng()),

--- a/chainbench/test_data/__init__.py
+++ b/chainbench/test_data/__init__.py
@@ -10,18 +10,18 @@ from .blockchain import (
     Tx,
     TxHash,
 )
-from .evm import EVMBlock, EVMTestData
+from .evm import EvmBlock, EvmTestData
 from .solana import SolanaBlock, SolanaTestData
 from .starknet import StarkNetBlock, StarkNetTestData
 
 __all__ = [
     "TestData",
-    "EVMTestData",
+    "EvmTestData",
     "SolanaTestData",
     "StarkNetTestData",
     "BlockchainData",
     "Block",
-    "EVMBlock",
+    "EvmBlock",
     "SolanaBlock",
     "StarkNetBlock",
     "BlockHash",

--- a/chainbench/test_data/blockchain.py
+++ b/chainbench/test_data/blockchain.py
@@ -34,7 +34,7 @@ def append_if_not_none(data: list | set, val: t.Any) -> None:
             data.add(val)
 
 
-class RPCError(Exception):
+class RpcError(Exception):
     def __init__(self, code: int, message: str):
         self.code = code
         self.message = message
@@ -121,7 +121,7 @@ class HttpxClient:
         # check if response is error
         if "error" in response_json:
             logger.error("Response is error: %s", response_json["error"]["message"])
-            raise RPCError(code=response_json["error"]["code"], message=response_json["error"]["message"])
+            raise RpcError(code=response_json["error"]["code"], message=response_json["error"]["message"])
 
         # check if response is valid
         if "result" not in response_json:

--- a/chainbench/test_data/ethereum.py
+++ b/chainbench/test_data/ethereum.py
@@ -1,0 +1,155 @@
+import json
+import logging
+import typing as t
+from argparse import Namespace
+from dataclasses import dataclass
+
+from chainbench.test_data.blockchain import (
+    Block,
+    BlockNotFoundError,
+    BlockNumber,
+    BlockRange,
+    TestData,
+)
+from chainbench.util.rng import RNG
+
+logger = logging.getLogger(__name__)
+
+Epoch = int
+
+
+class EthValidatorStatus:
+    ACTIVE = "active"
+    ACTIVE_ONGOING = "active_ongoing"
+    ACTIVE_EXITING = "active_exiting"
+    ACTIVE_SLASHED = "active_slashed"
+    PENDING = "pending"
+    PENDING_ONGOING = "pending_ongoing"
+    PENDING_INITIALIZED = "pending_initialized"
+    EXITED = "exited"
+    EXITED_UNSLASHED = "exited_unslashed"
+    EXITED_SLASHED = "exited_slashed"
+    WITHDRAWAL = "withdrawal"
+    WITHDRAWAL_DONE = "withdrawal_done"
+    WITHDRAWAL_POSSIBLE = "withdrawal_possible"
+
+
+EthValidatorStatuses = [v for k, v in EthValidatorStatus.__dict__.items() if not k.startswith("_")]
+
+
+@dataclass(frozen=True)
+class EthValidator:
+    index: str
+
+
+@dataclass(frozen=True)
+class EthCommittee:
+    index: str
+    validators: list[EthValidator]
+
+    def to_dict(self):
+        return {
+            "index": self.index,
+            "validators": [validator.__dict__ for validator in self.validators],
+        }
+
+
+@dataclass(frozen=True)
+class EthConsensusBlock(Block):
+    epoch: int
+    committees: list[EthCommittee]
+
+    def to_json(self):
+        return json.dumps(
+            {
+                "block_number": self.block_number,
+                "epoch": self.epoch,
+                "committees": [committee.to_dict() for committee in self.committees],
+            }
+        )
+
+    @classmethod
+    def from_response(cls, slot: BlockNumber, data: dict[str, t.Any]):
+        epoch = slot // 32
+        committees = []
+        for committee in data["data"]:
+            validators = []
+            for validator in committee["validators"]:
+                validators.append(EthValidator(validator))
+            committees.append(EthCommittee(committee["index"], validators))
+        return EthConsensusBlock(slot, epoch, committees)
+
+    def get_random_committee(self, rng: RNG) -> EthCommittee:
+        return rng.random.choice(self.committees)
+
+    def get_random_committee_index(self, rng: RNG) -> str:
+        return self.get_random_committee(rng).index
+
+    def get_random_validator_index(self, rng: RNG) -> str:
+        return rng.random.choice(self.get_random_committee(rng).validators).index
+
+    def get_random_validator_indexes(self, count: int, rng: RNG) -> list[str]:
+        start_index = rng.random.randint(0, 128 - count)
+        committee = self.get_random_committee(rng)
+        return [validator.index for validator in committee.validators[start_index : start_index + count]]
+
+
+class EthConsensusTestData(TestData[EthConsensusBlock]):
+    def fetch_block_header(self, block_id: int | str) -> dict[str, t.Any]:
+        block_response = self.client.get(f"/eth/v1/beacon/headers/{block_id}")
+        if block_response.status_code == 404:
+            raise BlockNotFoundError
+        return self.client.get_json(block_response)["data"]["header"]["message"]
+
+    def fetch_block(self, block_id: int | str) -> EthConsensusBlock:
+        if isinstance(block_id, str):
+            if (block_id := block_id.lower()) not in (
+                "head",
+                "genesis",
+                "finalized",
+            ):
+                raise ValueError("Invalid block identifier")
+        slot = int(self.fetch_block_header(block_id)["slot"])
+
+        committees_response = self.client.get(f"/eth/v1/beacon/states/{block_id}/committees", params={"slot": slot})
+        committees_json = self.client.get_json(committees_response)
+        return EthConsensusBlock.from_response(slot, committees_json)
+
+    def fetch_latest_block(self) -> EthConsensusBlock:
+        return self.fetch_block("head")
+
+    def fetch_latest_block_number(self) -> BlockNumber:
+        return int(self.fetch_block_header("head")["slot"])
+
+    def _get_start_and_end_blocks(self, parsed_options: Namespace) -> BlockRange:
+        end_block_number = self.fetch_latest_block_number()
+        if parsed_options.use_latest_blocks:
+            start_block_number = end_block_number - self.data.size.blocks_len + 1
+        else:
+            start_block_number = 1
+        logger.info("Using blocks from %s to %s as test data", start_block_number, end_block_number)
+        return BlockRange(start_block_number, end_block_number)
+
+    def get_block_from_data(self, data: dict[str, t.Any] | str) -> EthConsensusBlock:
+        def get_committee(committee: dict[str, t.Any]) -> EthCommittee:
+            return EthCommittee(
+                index=committee["index"],
+                validators=[EthValidator(index=validator["index"]) for validator in committee["validators"]],
+            )
+
+        if isinstance(data, str):
+            data_dict = json.loads(data)
+        else:
+            data_dict = data
+
+        slot = data_dict["block_number"]
+        epoch = slot // 32
+        committees = [get_committee(committee) for committee in data_dict["committees"]]
+        return EthConsensusBlock(slot, epoch, committees)
+
+    def get_random_epoch(self, rng: RNG) -> Epoch:
+        return self.get_random_block(rng).epoch
+
+    @staticmethod
+    def get_random_validator_status(rng: RNG) -> str:
+        return rng.random.choice(EthValidatorStatuses)

--- a/chainbench/test_data/evm.py
+++ b/chainbench/test_data/evm.py
@@ -244,10 +244,10 @@ class EvmTestData(TestData[EvmBlock]):
         return EvmBlock(**data_dict)
 
     def fetch_chain_id(self) -> ChainId:
-        return parse_hex_to_int(self.client.make_call("eth_chainId"))
+        return parse_hex_to_int(self.client.make_rpc_call("eth_chainId"))
 
     def fetch_latest_block_number(self) -> BlockNumber:
-        return parse_hex_to_int(self.client.make_call("eth_blockNumber"))
+        return parse_hex_to_int(self.client.make_rpc_call("eth_blockNumber"))
 
     def fetch_block(self, block_number: BlockNumber | str) -> EvmBlock:
         if isinstance(block_number, int):
@@ -258,7 +258,7 @@ class EvmTestData(TestData[EvmBlock]):
             "pending",
         ]:
             raise ValueError("Invalid block number")
-        result: dict[str, t.Any] = self.client.make_call("eth_getBlockByNumber", [block_number, True])
+        result: dict[str, t.Any] = self.client.make_rpc_call("eth_getBlockByNumber", [block_number, True])
         return EvmBlock.from_response(parse_hex_to_int(result["number"]), result)
 
     def _get_start_and_end_blocks(self, parsed_options: Namespace) -> BlockRange:

--- a/chainbench/test_data/evm.py
+++ b/chainbench/test_data/evm.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 ChainId = int
 
 
-class ERC20Contract(SmartContract):
+class Erc20Contract(SmartContract):
     def total_supply_params(self) -> dict[str, str]:
         return {"data": "0x18160ddd", "to": self.address}
 
@@ -40,7 +40,7 @@ class ERC20Contract(SmartContract):
         return {"data": "0x06fdde03", "to": self.address}
 
 
-class EVMNetwork:
+class EvmNetwork:
     def __new__(cls, chain_id: ChainId):
         if chain_id not in cls.DATA:
             raise ValueError(f"Unsupported chain id: {chain_id}")
@@ -68,10 +68,10 @@ class EVMNetwork:
         else:
             return result
 
-    def get_contracts(self) -> list[ERC20Contract]:
-        return [ERC20Contract(address) for address in self.contract_addresses]
+    def get_contracts(self) -> list[Erc20Contract]:
+        return [Erc20Contract(address) for address in self.contract_addresses]
 
-    def get_random_contract(self, rng: RNG) -> ERC20Contract:
+    def get_random_contract(self, rng: RNG) -> Erc20Contract:
         return rng.random.choice(self.get_contracts())
 
     DATA: t.Mapping[ChainId, NetworkData] = {
@@ -188,7 +188,7 @@ class EVMNetwork:
 
 
 @dataclass(frozen=True)
-class EVMBlock(Block):
+class EvmBlock(Block):
     block_hash: BlockHash
     txs: list[Tx]
     tx_hashes: list[TxHash]
@@ -219,13 +219,13 @@ class EVMBlock(Block):
         return rng.random.choice(self.accounts)
 
 
-class EVMTestData(TestData[EVMBlock]):
-    def __init__(self, network: EVMNetwork | None = None):
+class EvmTestData(TestData[EvmBlock]):
+    def __init__(self, network: EvmNetwork | None = None):
         super().__init__()
         self._network = network
 
     def init_network(self, chain_id: ChainId):
-        self._network = EVMNetwork(chain_id)
+        self._network = EvmNetwork(chain_id)
 
     @property
     def network(self):
@@ -233,15 +233,15 @@ class EVMTestData(TestData[EVMBlock]):
             raise RuntimeError("Network is not set")
         return self._network
 
-    def get_random_erc20_contract(self, rng: RNG) -> ERC20Contract:
+    def get_random_erc20_contract(self, rng: RNG) -> Erc20Contract:
         return self.network.get_random_contract(rng)
 
-    def get_block_from_data(self, data: dict[str, t.Any] | str) -> EVMBlock:
+    def get_block_from_data(self, data: dict[str, t.Any] | str) -> EvmBlock:
         if isinstance(data, str):
             data_dict = json.loads(data)
         else:
             data_dict = data
-        return EVMBlock(**data_dict)
+        return EvmBlock(**data_dict)
 
     def fetch_chain_id(self) -> ChainId:
         return parse_hex_to_int(self.client.make_call("eth_chainId"))
@@ -249,7 +249,7 @@ class EVMTestData(TestData[EVMBlock]):
     def fetch_latest_block_number(self) -> BlockNumber:
         return parse_hex_to_int(self.client.make_call("eth_blockNumber"))
 
-    def fetch_block(self, block_number: BlockNumber | str) -> EVMBlock:
+    def fetch_block(self, block_number: BlockNumber | str) -> EvmBlock:
         if isinstance(block_number, int):
             block_number = hex(block_number)
         elif (block_number := block_number.lower()) not in [
@@ -259,7 +259,7 @@ class EVMTestData(TestData[EVMBlock]):
         ]:
             raise ValueError("Invalid block number")
         result: dict[str, t.Any] = self.client.make_call("eth_getBlockByNumber", [block_number, True])
-        return EVMBlock.from_response(parse_hex_to_int(result["number"]), result)
+        return EvmBlock.from_response(parse_hex_to_int(result["number"]), result)
 
     def _get_start_and_end_blocks(self, parsed_options: Namespace) -> BlockRange:
         end_block_number = self.fetch_latest_block_number()

--- a/chainbench/test_data/solana.py
+++ b/chainbench/test_data/solana.py
@@ -61,7 +61,7 @@ class SolanaTestData(TestData[SolanaBlock]):
         return SolanaBlock(**data_dict)
 
     def fetch_latest_block_number(self) -> Slot:
-        slot = self.client.make_call("getLatestBlockhash")["context"]["slot"]
+        slot = self.client.make_rpc_call("getLatestBlockhash")["context"]["slot"]
         return slot
 
     def fetch_block(self, slot: Slot) -> SolanaBlock:
@@ -72,7 +72,7 @@ class SolanaTestData(TestData[SolanaBlock]):
             "maxSupportedTransactionVersion": 0,
         }
         try:
-            result = self.client.make_call("getBlock", [slot, config_object])
+            result = self.client.make_rpc_call("getBlock", [slot, config_object])
         except RpcError as e:
             self._logger.error(f"Failed to fetch block {slot}: {e.code} {e.message}")
             print(f"Failed to fetch block {slot}: {e.code} {e.message}")
@@ -89,7 +89,7 @@ class SolanaTestData(TestData[SolanaBlock]):
         return self.fetch_block(self.fetch_latest_block_number())
 
     def _fetch_first_available_block(self) -> Slot:
-        slot = self.client.make_call("getFirstAvailableBlock")
+        slot = self.client.make_rpc_call("getFirstAvailableBlock")
         return slot
 
     def _get_start_and_end_blocks(self, parsed_options: Namespace) -> BlockRange:

--- a/chainbench/test_data/solana.py
+++ b/chainbench/test_data/solana.py
@@ -14,13 +14,13 @@ from .blockchain import (
     BlockNotFoundError,
     BlockNumber,
     BlockRange,
-    RPCError,
+    RpcError,
     TestData,
     Tx,
     TxHash,
     append_if_not_none,
 )
-from .evm import EVMBlock
+from .evm import EvmBlock
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ Slot = BlockNumber
 
 
 @dataclass(frozen=True)
-class SolanaBlock(EVMBlock):
+class SolanaBlock(EvmBlock):
     block_height: BlockNumber
 
     @classmethod
@@ -73,7 +73,7 @@ class SolanaTestData(TestData[SolanaBlock]):
         }
         try:
             result = self.client.make_call("getBlock", [slot, config_object])
-        except RPCError as e:
+        except RpcError as e:
             self._logger.error(f"Failed to fetch block {slot}: {e.code} {e.message}")
             print(f"Failed to fetch block {slot}: {e.code} {e.message}")
 

--- a/chainbench/test_data/starknet.py
+++ b/chainbench/test_data/starknet.py
@@ -11,12 +11,12 @@ from .blockchain import (
     append_if_not_none,
     parse_hex_to_int,
 )
-from .evm import ChainId, EVMBlock, EVMTestData
+from .evm import ChainId, EvmBlock, EvmTestData
 
 logger = logging.getLogger(__name__)
 
 
-class StarkNetBlock(EVMBlock):
+class StarkNetBlock(EvmBlock):
     @classmethod
     def from_response(cls, block_number: BlockNumber, data: dict[str, t.Any]):
         block_hash: BlockHash = data["block_hash"]
@@ -36,7 +36,7 @@ class StarkNetBlock(EVMBlock):
         return cls(block_number, block_hash, txs, tx_hashes, list(accounts))
 
 
-class StarkNetTestData(EVMTestData):
+class StarkNetTestData(EvmTestData):
     def get_block_from_data(self, data: dict[str, t.Any] | str) -> StarkNetBlock:
         if isinstance(data, str):
             data_dict: dict[str, t.Any] = json.loads(data)

--- a/chainbench/test_data/starknet.py
+++ b/chainbench/test_data/starknet.py
@@ -2,7 +2,15 @@ import json
 import logging
 import typing as t
 
-from .blockchain import Account, BlockHash, BlockNumber, Tx, TxHash
+from .blockchain import (
+    Account,
+    BlockHash,
+    BlockNumber,
+    Tx,
+    TxHash,
+    append_if_not_none,
+    parse_hex_to_int,
+)
 from .evm import ChainId, EVMBlock, EVMTestData
 
 logger = logging.getLogger(__name__)
@@ -19,10 +27,10 @@ class StarkNetBlock(EVMBlock):
             if index == 100:
                 # limit it to 100 per block
                 break
-            cls._append_if_not_none(tx_hashes, tx["transaction_hash"])
-            cls._append_if_not_none(txs, tx)
+            append_if_not_none(tx_hashes, tx["transaction_hash"])
+            append_if_not_none(txs, tx)
             try:
-                cls._append_if_not_none(accounts, tx["sender_address"])
+                append_if_not_none(accounts, tx["sender_address"])
             except KeyError:
                 pass  # skip tx if it doesn't have sender_address
         return cls(block_number, block_hash, txs, tx_hashes, list(accounts))
@@ -37,7 +45,7 @@ class StarkNetTestData(EVMTestData):
         return StarkNetBlock(**data_dict)
 
     def fetch_chain_id(self) -> ChainId:
-        return self._parse_hex_to_int(self.client.make_call("starknet_chainId"))
+        return parse_hex_to_int(self.client.make_call("starknet_chainId"))
 
     def fetch_latest_block_number(self) -> BlockNumber:
         return self.client.make_call("starknet_blockNumber")

--- a/chainbench/test_data/starknet.py
+++ b/chainbench/test_data/starknet.py
@@ -45,10 +45,10 @@ class StarkNetTestData(EvmTestData):
         return StarkNetBlock(**data_dict)
 
     def fetch_chain_id(self) -> ChainId:
-        return parse_hex_to_int(self.client.make_call("starknet_chainId"))
+        return parse_hex_to_int(self.client.make_rpc_call("starknet_chainId"))
 
     def fetch_latest_block_number(self) -> BlockNumber:
-        return self.client.make_call("starknet_blockNumber")
+        return self.client.make_rpc_call("starknet_blockNumber")
 
     def fetch_block(self, block_number: BlockNumber | str) -> StarkNetBlock:
         if isinstance(block_number, str) and (block_number := block_number.lower()) not in (
@@ -58,5 +58,5 @@ class StarkNetTestData(EvmTestData):
             raise ValueError("Invalid block number")
         params: dict[str, int] | str = {"block_number": block_number} if isinstance(block_number, int) else block_number
 
-        result = self.client.make_call("starknet_getBlockWithTxs", [params])
+        result = self.client.make_rpc_call("starknet_getBlockWithTxs", [params])
         return StarkNetBlock.from_response(result["block_number"], result)

--- a/chainbench/tools/discovery/rpc.py
+++ b/chainbench/tools/discovery/rpc.py
@@ -10,13 +10,13 @@ __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file
 
 
 @dataclass
-class RPCMethod:
+class RpcMethod:
     name: str
     supported_clients: list[str]
 
 
 @dataclass
-class RPCClient:
+class RpcClient:
     name: str
     version: str
     endpoints: list[str]
@@ -48,7 +48,7 @@ class DiscoveryResult:
             return f"{self.method}, {self.error_message}"
 
 
-class RPCDiscovery:
+class RpcDiscovery:
     METHODS_FILE = Path(os.path.join(__location__, "methods.json"))
     CLIENTS_FILE = Path(os.path.join(__location__, "clients.json"))
 
@@ -60,23 +60,23 @@ class RPCDiscovery:
         self.http = httpx.Client()
 
     @staticmethod
-    def _parse_methods() -> list[RPCMethod]:
+    def _parse_methods() -> list[RpcMethod]:
         methods = []
-        methods_json = json.loads(RPCDiscovery.METHODS_FILE.read_text())
+        methods_json = json.loads(RpcDiscovery.METHODS_FILE.read_text())
         for method in methods_json.keys():
-            methods.append(RPCMethod(name=method, supported_clients=methods_json[method]["clients"]))
+            methods.append(RpcMethod(name=method, supported_clients=methods_json[method]["clients"]))
         return methods
 
     @staticmethod
-    def _parse_clients() -> list[RPCClient]:
-        clients = []
-        clients_json = json.loads(RPCDiscovery.CLIENTS_FILE.read_text())
+    def _parse_clients() -> list[RpcClient]:
+        clients: list[RpcClient] = []
+        clients_json = json.loads(RpcDiscovery.CLIENTS_FILE.read_text())
         for client in clients_json.keys():
             if "endpoints" in clients_json[client]:
                 endpoints = clients_json[client]["endpoints"]
             else:
                 endpoints = []
-            clients.append(RPCClient(name=client, version=clients_json[client]["version"], endpoints=endpoints))
+            clients.append(RpcClient(name=client, version=clients_json[client]["version"], endpoints=endpoints))
         return clients
 
     @classmethod
@@ -94,7 +94,7 @@ class RPCDiscovery:
         return [client.name for client in cls._parse_clients()]
 
     @classmethod
-    def get_clients(cls) -> list[RPCClient]:
+    def get_clients(cls) -> list[RpcClient]:
         return cls._parse_clients()
 
     @classmethod

--- a/chainbench/tools/test_method.py
+++ b/chainbench/tools/test_method.py
@@ -4,7 +4,7 @@ User profile for testing a specific EVM method.
 from locust import constant_pacing, events, task
 from locust.argument_parser import LocustArgumentParser
 
-from chainbench.user import EVMMethods
+from chainbench.user import EvmMethods
 from chainbench.util.cli import get_subclass_methods, method_to_task, task_to_method
 
 
@@ -14,13 +14,13 @@ def _(parser: LocustArgumentParser) -> None:
         "--method",
         type=str,
         default="eth_blocknumber",
-        choices=[task_to_method(method) for method in get_subclass_methods(EVMMethods)],
+        choices=[task_to_method(method) for method in get_subclass_methods(EvmMethods)],
         help="Test a specific method",
         include_in_web_ui=True,
     )
 
 
-class TestEVMMethod(EVMMethods):
+class TestEVMMethod(EvmMethods):
     wait_time = constant_pacing(1)
 
     @task

--- a/chainbench/user/__init__.py
+++ b/chainbench/user/__init__.py
@@ -1,14 +1,18 @@
 from chainbench.util.event import setup_event_listeners
 
 from .evm import EVMMethods, EVMUser
-from .jsonrpc import JsonRPCUser
+from .http import HttpUser, JsonRPCUser
 from .solana import SolanaUser
 from .starknet import StarkNetUser
+
+# importing plugins here as all profiles depend on it
+import locust_plugins  # isort: skip  # noqa
 
 setup_event_listeners()
 
 __all__ = [
     "EVMUser",
+    "HttpUser",
     "JsonRPCUser",
     "SolanaUser",
     "StarkNetUser",

--- a/chainbench/user/__init__.py
+++ b/chainbench/user/__init__.py
@@ -1,7 +1,7 @@
 from chainbench.util.event import setup_event_listeners
 
-from .evm import EVMMethods, EVMUser
-from .http import HttpUser, JsonRPCUser
+from .evm import EvmMethods, EvmUser
+from .http import ChainbenchHttpUser, JsonRpcUser
 from .solana import SolanaUser
 from .starknet import StarkNetUser
 
@@ -11,10 +11,10 @@ import locust_plugins  # isort: skip  # noqa
 setup_event_listeners()
 
 __all__ = [
-    "EVMUser",
-    "HttpUser",
-    "JsonRPCUser",
+    "EvmUser",
+    "ChainbenchHttpUser",
+    "JsonRpcUser",
     "SolanaUser",
     "StarkNetUser",
-    "EVMMethods",
+    "EvmMethods",
 ]

--- a/chainbench/user/__init__.py
+++ b/chainbench/user/__init__.py
@@ -1,7 +1,7 @@
 from chainbench.util.event import setup_event_listeners
 
 from .evm import EvmMethods, EvmUser
-from .http import ChainbenchHttpUser, JsonRpcUser
+from .http import HttpUser, JsonRpcUser
 from .solana import SolanaUser
 from .starknet import StarkNetUser
 
@@ -12,7 +12,7 @@ setup_event_listeners()
 
 __all__ = [
     "EvmUser",
-    "ChainbenchHttpUser",
+    "HttpUser",
     "JsonRpcUser",
     "SolanaUser",
     "StarkNetUser",

--- a/chainbench/user/ethereum.py
+++ b/chainbench/user/ethereum.py
@@ -2,12 +2,13 @@ import logging
 import typing as t
 
 from chainbench.test_data.ethereum import EthConsensusTestData
-from chainbench.user import ChainbenchHttpUser
+
+from .http import HttpUser
 
 logger = logging.getLogger(__name__)
 
 
-class EthConsensusUser(ChainbenchHttpUser):
+class EthConsensusUser(HttpUser):
     abstract = True
     test_data = EthConsensusTestData()
 
@@ -18,7 +19,7 @@ class EthConsensusUser(ChainbenchHttpUser):
         block_id: int | str = "head",
         path: str | None = None,
     ):
-        url_path: str = f"/eth/{version}/beacon/blocks/{block_id}"
+        url_path = f"/eth/{version}/beacon/blocks/{block_id}"
         if path:
             url_path += "/" + path.strip("/")
         self.get(

--- a/chainbench/user/ethereum.py
+++ b/chainbench/user/ethereum.py
@@ -1,0 +1,178 @@
+import logging
+import typing as t
+
+from chainbench.test_data.ethereum import EthConsensusTestData
+from chainbench.user import HttpUser
+
+logger = logging.getLogger(__name__)
+
+
+class EthConsensusUser(HttpUser):
+    abstract = True
+    test_data = EthConsensusTestData()
+
+    def eth_beacon_blocks_request(
+        self,
+        name: str = "eth_beacon_blocks",
+        version: str = "v1",
+        block_id: int | str = "head",
+        path: str | None = None,
+    ):
+        url_path: str = f"/eth/{version}/beacon/blocks/{block_id}"
+        if path:
+            url_path += "/" + path.strip("/")
+        self.get(
+            name=name,
+            url_postfix=url_path,
+        )
+
+    def eth_v1_beacon_states_validators_request(
+        self,
+        name: str = "eth_v1_beacon_states_validators",
+        state_id: int | str = "head",
+        validator_status: str | None = None,
+        validator_ids: list[str] | None = None,
+    ):
+        params: dict[str, t.Any] = {}
+        if validator_status:
+            params = {"status": validator_status}
+        if validator_ids:
+            params = {"id": validator_ids}
+
+        self.get(
+            name=name,
+            url_postfix=f"/eth/v1/beacon/states/{state_id}/validators",
+            params=params,
+        )
+
+    def eth_v1_beacon_headers_request(self, name: str = "eth_v1_beacon_headers", block_id: int | str = "head"):
+        self.get(
+            name=name,
+            url_postfix=f"/eth/v1/beacon/headers/{block_id}",
+        )
+
+
+class EthConsensusMethods(EthConsensusUser):
+    abstract = True
+
+    def eth_v1_beacon_genesis_task(self):
+        self.get(
+            name="eth_v1_beacon_genesis",
+            url_postfix="/eth/v1/beacon/genesis",
+        )
+
+    def eth_v1_config_spec_task(self):
+        self.get(
+            name="eth_v1_config_spec",
+            url_postfix="/eth/v1/config/spec",
+        )
+
+    def eth_v2_beacon_blocks_head_task(self):
+        self.eth_beacon_blocks_request(name="eth_v2_beacon_blocks_head", version="v2")
+
+    def eth_v2_beacon_blocks_finalized_task(self):
+        self.eth_beacon_blocks_request(name="eth_v2_beacon_blocks_finalized", version="v2", block_id="finalized")
+
+    def eth_v2_beacon_blocks_random_block_id_task(self):
+        self.eth_beacon_blocks_request(
+            name="eth_v2_beacon_blocks_random_block_id",
+            version="v2",
+            block_id=self.test_data.get_random_block_number(self.rng.get_rng()),
+        )
+
+    def eth_v1_beacon_blocks_random_block_id_root_task(self):
+        self.eth_beacon_blocks_request(
+            name="eth_v1_beacon_blocks_random_block_id_root",
+            block_id=self.test_data.get_random_block_number(self.rng.get_rng()),
+            path="root",
+        )
+
+    def eth_v1_beacon_blocks_random_block_id_attestations_task(self):
+        self.eth_beacon_blocks_request(
+            name="eth_v1_beacon_blocks_random_block_id_attestations",
+            block_id=self.test_data.get_random_block_number(self.rng.get_rng()),
+            path="attestations",
+        )
+
+    def eth_v1_beacon_states_validators_head_task(self):
+        self.eth_v1_beacon_states_validators_request(
+            name="eth_v1_beacon_states_validators_head",
+        )
+
+    def eth_v1_beacon_states_validators_random_state_id_task(self):
+        self.eth_v1_beacon_states_validators_request(
+            name="eth_v1_beacon_states_validators_random_state_id",
+            state_id=self.test_data.get_random_block(self.rng.get_rng()).block_number,
+        )
+
+    def eth_v1_beacon_states_validators_random_status_task(self):
+        self.eth_v1_beacon_states_validators_request(
+            name="eth_v1_beacon_states_validators_random_status",
+            state_id=self.test_data.get_random_block(self.rng.get_rng()).block_number,
+            validator_status=self.test_data.get_random_validator_status(self.rng.get_rng()),
+        )
+
+    def eth_v1_beacon_states_validators_random_ids_task(self):
+        block = self.test_data.get_random_block(self.rng.get_rng())
+        validator_count = self.rng.get_rng().random.randint(50, 100)
+        self.eth_v1_beacon_states_validators_request(
+            name="eth_v1_beacon_states_validators_random_ids",
+            state_id=block.block_number,
+            validator_ids=block.get_random_validator_indexes(validator_count, self.rng.get_rng()),
+        )
+
+    def eth_v1_beacon_states_validators_random_validator_status_task(self):
+        self.eth_v1_beacon_states_validators_request(
+            name="eth_v1_beacon_states_validators_random_validator_status",
+            state_id=self.test_data.get_random_block(self.rng.get_rng()).block_number,
+            validator_status=self.test_data.get_random_validator_status(self.rng.get_rng()),
+        )
+
+    def eth_v1_beacon_states_random_state_id_finality_checkpoints_task(self):
+        self.get(
+            name="eth_v1_beacon_states_finality_checkpoints",
+            url_postfix=f"/eth/v1/beacon/states/"
+            f"{self.test_data.get_random_block(self.rng.get_rng()).block_number}/finality_checkpoints",
+        )
+
+    def eth_v1_validator_duties_proposer_random_epoch_task(self):
+        self.get(
+            name="eth_v1_validator_duties_proposer_random_epoch",
+            url_postfix=f"/eth/v1/validator/duties/proposer/{self.test_data.get_random_epoch(self.rng.get_rng())}",
+        )
+
+    def eth_v1_beacon_states_head_committees_task(self):
+        self.get(
+            name="eth_v1_beacon_states_committees",
+            url_postfix="/eth/v1/beacon/states/head/committees",
+        )
+
+    def eth_v1_beacon_states_head_committees_random_epoch_task(self):
+        self.get(
+            name="eth_v1_beacon_states_committees_random_epoch",
+            url_postfix=f"/eth/v1/beacon/states/head/committees?"
+            f"epoch={self.test_data.get_random_epoch(self.rng.get_rng())}",
+        )
+
+    def eth_v1_beacon_headers_head_task(self):
+        self.eth_v1_beacon_headers_request(
+            name="eth_v1_beacon_headers_head",
+        )
+
+    def eth_v1_beacon_headers_random_block_id_task(self):
+        self.eth_v1_beacon_headers_request(
+            name="eth_v1_beacon_headers_random_block_id",
+            block_id=self.test_data.get_random_block_number(self.rng.get_rng()),
+        )
+
+    def eth_v1_node_health_task(self):
+        self.get(
+            name="eth_v1_node_health",
+            url_postfix="/eth/v1/node/health",
+        )
+
+    def eth_v1_node_version_task(self):
+        self.get(
+            name="eth_v1_node_version",
+            url_postfix="/eth/v1/node/version",
+        )

--- a/chainbench/user/ethereum.py
+++ b/chainbench/user/ethereum.py
@@ -2,12 +2,12 @@ import logging
 import typing as t
 
 from chainbench.test_data.ethereum import EthConsensusTestData
-from chainbench.user import HttpUser
+from chainbench.user import ChainbenchHttpUser
 
 logger = logging.getLogger(__name__)
 
 
-class EthConsensusUser(HttpUser):
+class EthConsensusUser(ChainbenchHttpUser):
     abstract = True
     test_data = EthConsensusTestData()
 

--- a/chainbench/user/evm.py
+++ b/chainbench/user/evm.py
@@ -1,12 +1,12 @@
-from chainbench.test_data import Account, BlockHash, BlockNumber, EVMTestData, TxHash
+from chainbench.test_data import Account, BlockHash, BlockNumber, EvmTestData, TxHash
 from chainbench.util.rng import RNG
 
-from .http import JsonRPCUser
+from .http import JsonRpcUser
 
 
-class EVMUser(JsonRPCUser):
+class EvmUser(JsonRpcUser):
     abstract = True
-    test_data = EVMTestData()
+    test_data = EvmTestData()
 
     _default_trace_timeout = "120s"
 
@@ -133,7 +133,7 @@ class EVMUser(JsonRPCUser):
         ]
 
 
-class EVMMethods(EVMUser):
+class EvmMethods(EvmUser):
     abstract = True
 
     def eth_accounts_task(self) -> None:

--- a/chainbench/user/evm.py
+++ b/chainbench/user/evm.py
@@ -137,118 +137,118 @@ class EvmMethods(EvmUser):
     abstract = True
 
     def eth_accounts_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="eth_accounts",
         )
 
     def eth_block_number_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="eth_blockNumber",
         )
 
     def eth_call_task(self):
-        self.make_call(
+        self.make_rpc_call(
             method="eth_call",
             params=self._erc20_eth_call_params_factory(self.rng.get_rng()),
         )
 
     def eth_chain_id_task(self):
-        self.make_call(
+        self.make_rpc_call(
             method="eth_chainId",
         )
 
     def eth_estimate_gas_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="eth_estimate_gas",
             method="eth_estimateGas",
             params=self._erc20_eth_call_params_factory(self.rng.get_rng()),
         )
 
     def eth_fee_history_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="eth_feeHistory",
             params=self._eth_fee_history_params_factory(self.rng.get_rng()),
         )
 
     def eth_gas_price_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="eth_gasPrice",
         )
 
     def eth_get_logs_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="eth_getLogs",
             params=self._get_logs_params_factory(self.rng.get_rng()),
         )
 
     def eth_get_balance_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="eth_getBalance",
             params=self._get_account_and_block_number_params_factory_latest(self.rng.get_rng()),
         )
 
     def eth_get_block_by_hash_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="eth_getBlockByHash",
             params=self._block_by_hash_params_factory(self.rng.get_rng()),
         )
 
     def eth_get_block_by_number_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="eth_getBlockByNumber",
             params=self._block_params_factory(),
         )
 
     def eth_get_block_receipts_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="eth_getBlockReceipts",
             params=[hex(self.test_data.get_random_block_number(self.rng.get_rng()))],
         )
 
     def eth_get_block_transaction_count_by_hash_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="eth_getBlockTransactionCountByHash",
             params=[self.test_data.get_random_block_hash(self.rng.get_rng())],
         )
 
     def eth_get_block_transaction_count_by_number_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="eth_getBlockTransactionCountByNumber",
             params=[hex(self.test_data.get_random_block_number(self.rng.get_rng()))],
         )
 
     def eth_get_code_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="eth_getCode",
             params=self._erc20_eth_get_code_params_factory(self.rng.get_rng()),
         )
 
     def eth_get_header_by_hash_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="eth_getHeaderByHash",
             params=[self.test_data.get_random_block_hash(self.rng.get_rng())],
         )
 
     def eth_get_header_by_number_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="eth_getHeaderByNumber",
             params=[hex(self.test_data.get_random_block_number(self.rng.get_rng()))],
         )
 
     def eth_get_transaction_by_hash_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="eth_getTransactionByHash",
             params=self._transaction_by_hash_params_factory(self.rng.get_rng()),
         )
 
     def eth_get_transaction_receipt_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="eth_getTransactionReceipt",
             params=self._transaction_by_hash_params_factory(self.rng.get_rng()),
         )
 
     def eth_get_transaction_by_block_hash_and_index_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="eth_getTransactionByBlockHashAndIndex",
             params=[
                 self.test_data.get_random_block_hash(self.rng.get_rng()),
@@ -257,7 +257,7 @@ class EvmMethods(EvmUser):
         )
 
     def eth_get_transaction_by_block_number_and_index_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="eth_getTransactionByBlockNumberAndIndex",
             params=[
                 hex(self.test_data.get_random_block_number(self.rng.get_rng())),
@@ -266,103 +266,103 @@ class EvmMethods(EvmUser):
         )
 
     def eth_get_transaction_count_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="eth_getTransactionCount",
             params=self._get_account_and_block_number_params_factory_latest(self.rng.get_rng()),
         )
 
     def eth_get_uncle_count_by_block_hash_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="eth_getUncleCountByBlockHash",
             params=[self.test_data.get_random_block_hash(self.rng.get_rng())],
         )
 
     def eth_get_uncle_count_by_block_number_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="eth_getUncleCountByBlockNumber",
             params=[hex(self.test_data.get_random_block_number(self.rng.get_rng()))],
         )
 
     def eth_max_priority_fee_per_gas_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="eth_maxPriorityFeePerGas",
         )
 
     def eth_syncing_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="eth_syncing",
         )
 
     def debug_trace_block_by_hash_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="debug_traceBlockByHash",
             params=self._debug_trace_block_by_hash_params_factory(self.rng.get_rng()),
         )
 
     def debug_trace_block_by_number_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="debug_traceBlockByNumber",
             params=self._debug_trace_block_by_number_params_factory(),
         )
 
     def debug_trace_call_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="debug_traceCall",
             params=self._debug_trace_call_params_factory(self.rng.get_rng()),
         )
 
     def debug_trace_transaction_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="debug_traceTransaction",
             params=self._debug_trace_transaction_params_factory(self.rng.get_rng()),
         )
 
     def net_listening_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="net_listening",
         )
 
     def net_peer_count_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="net_peerCount",
         )
 
     def net_version_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="net_version",
         )
 
     def trace_block_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="trace_block",
             params=self._block_params_factory(),
         )
 
     def trace_replay_block_transactions_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="trace_replayBlockTransactions",
             params=self._trace_replay_block_transaction_params_factory(),
         )
 
     def trace_replay_transaction_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="trace_replayTransaction",
             params=self._trace_replay_transaction_params_factory(self.rng.get_rng()),
         )
 
     def trace_transaction_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="trace_transaction",
             params=[self.test_data.get_random_tx_hash(self.rng.get_rng())],
         )
 
     def web3_client_version_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="web3_clientVersion",
         )
 
     def web3_sha3_task(self) -> None:
-        self.make_call(
+        self.make_rpc_call(
             method="web3_sha3",
             params=[self.test_data.get_random_tx_hash(self.rng.get_rng())],
         )

--- a/chainbench/user/evm.py
+++ b/chainbench/user/evm.py
@@ -1,7 +1,7 @@
 from chainbench.test_data import Account, BlockHash, BlockNumber, EVMTestData, TxHash
 from chainbench.util.rng import RNG
 
-from .jsonrpc import JsonRPCUser
+from .http import JsonRPCUser
 
 
 class EVMUser(JsonRPCUser):

--- a/chainbench/user/http.py
+++ b/chainbench/user/http.py
@@ -9,7 +9,7 @@ from chainbench.util.rng import RNGManager
 from chainbench.util.rpc import generate_request
 
 
-class HttpUser(FastHttpUser):
+class ChainbenchHttpUser(FastHttpUser):
     """Extension of FastHttpUser for Chainbench."""
 
     abstract = True
@@ -41,10 +41,10 @@ class HttpUser(FastHttpUser):
             self.logger.critical(f"Redirect error: {response.url}")
 
     def is_http_error(self, response: RestResponseContextManager) -> bool:
-        if response.request:
+        if response.request is not None:
             self.logger.debug(f"Request: {response.request.method} {response.request.url_split}")
-        if response.request.body:
-            self.logger.debug(f"{response.request.body}")
+            if response.request.body is not None:
+                self.logger.debug(f"{response.request.body}")
 
         """Check the response for errors."""
         if response.status_code != 200:
@@ -81,7 +81,7 @@ class HttpUser(FastHttpUser):
             return response
 
 
-class JsonRPCUser(HttpUser):
+class JsonRpcUser(ChainbenchHttpUser):
     """Extension of HttpUser to provide JsonRPC support."""
 
     rpc_path: str = ""

--- a/chainbench/user/http.py
+++ b/chainbench/user/http.py
@@ -8,26 +8,17 @@ from chainbench.test_data import TestData
 from chainbench.util.rng import RNGManager
 from chainbench.util.rpc import generate_request
 
-# importing plugins here as all profiles depend on it
-import locust_plugins  # isort: skip  # noqa
 
-
-class JsonRPCUser(FastHttpUser):
-    """Extension of FastHttpUser to provide JsonRPC support."""
+class HttpUser(FastHttpUser):
+    """Extension of FastHttpUser for Chainbench."""
 
     abstract = True
     test_data: TestData = TestData()
-
-    rpc_path: str = ""
-    rpc_error_code_exclusions: list[int] = []
+    logger = logging.getLogger(__name__)
+    rng = RNGManager()
 
     connection_timeout = 120
     network_timeout = 360
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.logger = logging.getLogger(__name__)
-        self.rng = RNGManager()
 
     def on_start(self) -> None:
         self.test_data.wait()
@@ -49,11 +40,11 @@ class JsonRPCUser(FastHttpUser):
         elif 300 <= response.status_code <= 399:
             self.logger.critical(f"Redirect error: {response.url}")
 
-    def check_response(self, response: RestResponseContextManager, name: str) -> None:
-        response_json: dict = response.js
-
+    def is_http_error(self, response: RestResponseContextManager) -> bool:
         if response.request:
-            self.logger.debug(f"Request: {response.request.body}")
+            self.logger.debug(f"Request: {response.request.method} {response.request.url_split}")
+        if response.request.body:
+            self.logger.debug(f"{response.request.body}")
 
         """Check the response for errors."""
         if response.status_code != 200:
@@ -63,31 +54,58 @@ class JsonRPCUser(FastHttpUser):
             )
             self.check_fatal(response)
             response.failure(f"Request failed with {response.status_code} code")
-            return
+            return True
+        return False
 
-        if response_json is None:
+    def is_json(self, response: RestResponseContextManager, name: str) -> bool:
+        if response.js is None:
             self.logger.error(f"Response for {name}  is not a JSON: {response.text}")
             response.failure(f"Response for {name}  is not a JSON")
-            return
+            return False
+        return True
 
-        if "jsonrpc" not in response_json:
+    def post(
+        self, name: str, data: t.Optional[dict] = None, params: t.Optional[dict] = None, url_postfix: str = ""
+    ) -> RestResponseContextManager | None:
+        with self.rest("POST", url_postfix.strip("/"), json=data, params=params, name=name) as response:
+            if self.is_http_error(response):
+                return None
+            return response
+
+    def get(
+        self, name: str, params: t.Optional[dict] = None, url_postfix: str = ""
+    ) -> RestResponseContextManager | None:
+        with self.rest("GET", url_postfix.strip("/"), params=params, name=name) as response:
+            if self.is_http_error(response):
+                return None
+            return response
+
+
+class JsonRPCUser(HttpUser):
+    """Extension of HttpUser to provide JsonRPC support."""
+
+    rpc_path: str = ""
+    rpc_error_code_exclusions: list[int] = []
+
+    def check_json_rpc_response(self, response: RestResponseContextManager, name: str) -> None:
+        if "jsonrpc" not in response.js:
             self.logger.error(f"Response for {name} is not a JSON-RPC: {response.text}")
             response.failure(f"Response for {name} is not a JSON-RPC")
             return
 
-        if "error" in response_json:
+        if "error" in response.js:
             self.logger.error(f"Response for {name} has a JSON-RPC error: {response.text}")
-            if "code" in response_json["error"]:
-                if response_json["error"]["code"] not in self.rpc_error_code_exclusions:
+            if "code" in response.js["error"]:
+                if response.js["error"]["code"] not in self.rpc_error_code_exclusions:
                     response.failure(
-                        f"Response for {name} has a JSON-RPC error {response_json['error']['code']} - "
-                        f"{response_json['error']['message']}"
+                        f"Response for {name} has a JSON-RPC error {response.js['error']['code']} - "
+                        f"{response.js['error']['message']}"
                     )
             else:
                 response.failure("Unspecified JSON-RPC error")
             return
 
-        if not response_json.get("result"):
+        if not response.js.get("result"):
             self.logger.error(f"Response for {name} call has no result: {response.text}")
 
     def make_call(
@@ -95,8 +113,8 @@ class JsonRPCUser(FastHttpUser):
     ) -> None:
         """Make a JSON-RPC call."""
         name = name if name else method
-        return self._post(name, data=generate_request(method, params), url_postfix=url_postfix)
 
-    def _post(self, name: str, data: t.Optional[dict] = None, url_postfix: str = "") -> None:
-        with self.rest("POST", self.rpc_path + url_postfix, json=data, name=name) as response:
-            self.check_response(response, name=name)
+        response = self.post(name, data=generate_request(method, params), url_postfix=self.rpc_path + url_postfix)
+        if response is not None:
+            if self.is_json(response, name=name):
+                self.check_json_rpc_response(response, name=name)

--- a/chainbench/user/http.py
+++ b/chainbench/user/http.py
@@ -9,7 +9,7 @@ from chainbench.util.rng import RNGManager
 from chainbench.util.rpc import generate_request
 
 
-class ChainbenchHttpUser(FastHttpUser):
+class HttpUser(FastHttpUser):
     """Extension of FastHttpUser for Chainbench."""
 
     abstract = True
@@ -81,10 +81,10 @@ class ChainbenchHttpUser(FastHttpUser):
             return response
 
 
-class JsonRpcUser(ChainbenchHttpUser):
+class JsonRpcUser(HttpUser):
     """Extension of HttpUser to provide JsonRPC support."""
 
-    rpc_path: str = ""
+    rpc_path = ""
     rpc_error_code_exclusions: list[int] = []
 
     def check_json_rpc_response(self, response: RestResponseContextManager, name: str) -> None:
@@ -108,7 +108,7 @@ class JsonRpcUser(ChainbenchHttpUser):
         if not response.js.get("result"):
             self.logger.error(f"Response for {name} call has no result: {response.text}")
 
-    def make_call(
+    def make_rpc_call(
         self, method: str, params: list[t.Any] | dict | None = None, name: str | None = None, url_postfix: str = ""
     ) -> None:
         """Make a JSON-RPC call."""

--- a/chainbench/user/solana.py
+++ b/chainbench/user/solana.py
@@ -1,7 +1,7 @@
 from chainbench.test_data import Account, BlockNumber, SolanaTestData, TxHash
 from chainbench.util.rng import RNG
 
-from .jsonrpc import JsonRPCUser
+from .http import JsonRPCUser
 
 
 class SolanaUser(JsonRPCUser):

--- a/chainbench/user/solana.py
+++ b/chainbench/user/solana.py
@@ -1,10 +1,10 @@
 from chainbench.test_data import Account, BlockNumber, SolanaTestData, TxHash
 from chainbench.util.rng import RNG
 
-from .http import JsonRPCUser
+from .http import JsonRpcUser
 
 
-class SolanaUser(JsonRPCUser):
+class SolanaUser(JsonRpcUser):
     abstract = True
     test_data = SolanaTestData()
     rpc_error_code_exclusions = [-32007]

--- a/chainbench/user/starknet.py
+++ b/chainbench/user/starknet.py
@@ -4,10 +4,10 @@ from chainbench.test_data import StarkNetTestData
 from chainbench.test_data.blockchain import Account, TxHash
 from chainbench.util.rng import RNG
 
-from .http import JsonRPCUser
+from .http import JsonRpcUser
 
 
-class StarkNetUser(JsonRPCUser):
+class StarkNetUser(JsonRpcUser):
     abstract = True
     test_data = StarkNetTestData()
 

--- a/chainbench/user/starknet.py
+++ b/chainbench/user/starknet.py
@@ -4,7 +4,7 @@ from chainbench.test_data import StarkNetTestData
 from chainbench.test_data.blockchain import Account, TxHash
 from chainbench.util.rng import RNG
 
-from .jsonrpc import JsonRPCUser
+from .http import JsonRPCUser
 
 
 class StarkNetUser(JsonRPCUser):

--- a/chainbench/util/event.py
+++ b/chainbench/util/event.py
@@ -9,7 +9,7 @@ from locust.env import Environment
 from locust.rpc import Message
 from locust.runners import STATE_CLEANUP, MasterRunner, WorkerRunner
 
-from chainbench.test_data import Block, EVMTestData, TestData
+from chainbench.test_data import Block, EvmTestData, TestData
 from chainbench.test_data.evm import ChainId
 from chainbench.util.timer import Timer
 
@@ -43,7 +43,7 @@ def setup_test_data(environment: Environment, msg: Message, **kwargs):
             if hasattr(user, "test_data"):
                 test_data_class_name: str = type(user.test_data).__name__
                 user.test_data.init_data_from_json(test_data[test_data_class_name])
-                if isinstance(user.test_data, EVMTestData):
+                if isinstance(user.test_data, EvmTestData):
                     chain_id: ChainId = test_data["chain_id"][test_data_class_name]
                     user.test_data.init_network(chain_id)
             else:
@@ -142,7 +142,7 @@ def on_init(environment: Environment, **_kwargs):
                 logger.info(f"Initializing test data for {test_data_class_name}")
                 print(f"Initializing test data for {test_data_class_name}")
                 user_test_data.init_http_client(environment.host)
-                if isinstance(user_test_data, EVMTestData):
+                if isinstance(user_test_data, EvmTestData):
                     chain_id: ChainId = user_test_data.fetch_chain_id()
                     user_test_data.init_network(chain_id)
                     logger.info(f"Target endpoint network is {user_test_data.network.name}")

--- a/docs/PROFILE.md
+++ b/docs/PROFILE.md
@@ -15,10 +15,10 @@ Let's create a profile for the Oasis blockchain. We will use the `Oasis` profile
 Let's create a new file called `oasis.py` in the `chainbench/profile/oasis/` directory and add the following code:
 
 ```python
-from chainbench.user import EVMUser
+from chainbench.user import EvmUser
 
 
-class OasisProfile(EVMUser):
+class OasisProfile(EvmUser):
     pass
 ```
 
@@ -33,11 +33,11 @@ If response time is greater than `n`, then the wait time is set to 0, and the ne
 There are other ways to set wait time, see the [Locust docs](https://docs.locust.io/en/stable/writing-a-locustfile.html#wait-time-attribute) for more details.
 
 ```python
-from chainbench.user import EVMUser
+from chainbench.user import EvmUser
 from locust import constant_pacing
 
 
-class OasisProfile(EVMUser):
+class OasisProfile(EvmUser):
     wait_time = constant_pacing(2)
 ```
 
@@ -52,12 +52,12 @@ The block ranges are defined in the [`chainbench/test_data/evm.py`](../chainbenc
 After that, blockchain data such as block numbers, block hashes, transactions, transaction hashes and addresses are fetched from the blockchain node and stored in memory.
 
 ```python
-from chainbench.user import EVMUser
+from chainbench.user import EvmUser
 from chainbench.util.rng import get_rng
 from locust import task, constant_pacing
 
 
-class OasisProfile(EVMUser):
+class OasisProfile(EvmUser):
     wait_time = constant_pacing(2)
 
     @task
@@ -81,12 +81,12 @@ See the [`chainbench/user/evm.py`](../chainbench/user/evm.py) file for all suppo
 Adding task for a call with static parameters is as simple as:
 
 ```python
-from chainbench.user import EVMUser
+from chainbench.user import EvmUser
 from chainbench.util.rng import get_rng
 from locust import task, constant_pacing
 
 
-class OasisProfile(EVMUser):
+class OasisProfile(EvmUser):
     wait_time = constant_pacing(2)
 
     @task
@@ -111,11 +111,11 @@ In case of `eth_syncing` we can omit the `params` argument because it doesn't ha
 Here's an example of `eth_call` call with static parameters from [BSC profile](../chainbench/profile/bsc/general.py):
 
 ```python
-from chainbench.user import EVMUser
+from chainbench.user import EvmUser
 from locust import task
 
 
-class BscProfile(EVMUser):
+class BscProfile(EvmUser):
     @task(100)
     def call_task(self):
         self.make_call(
@@ -137,12 +137,12 @@ If we want tasks to have different weights, we can use the `@task` decorator wit
 For `eth_getTransactionByHash` we can use the `_transaction_by_hash_params_factory` method:
 
 ```python
-from chainbench.user import EVMUser
+from chainbench.user import EvmUser
 from chainbench.util.rng import get_rng
 from locust import task, constant_pacing
 
 
-class OasisProfile(EVMUser):
+class OasisProfile(EvmUser):
     wait_time = constant_pacing(2)
 
     @task
@@ -174,12 +174,12 @@ class OasisProfile(EVMUser):
 `eth_getCode`, `eth_getBalance`, and `eth_getTransactionCount` share the same parameters format, so we can use the `_get_balance_params_factory` method:
 
 ```python
-from chainbench.user import EVMUser
+from chainbench.user import EvmUser
 from chainbench.util.rng import get_rng
 from locust import task, constant_pacing
 
 
-class OasisProfile(EVMUser):
+class OasisProfile(EvmUser):
     wait_time = constant_pacing(2)
 
     @task
@@ -235,12 +235,12 @@ class OasisProfile(EVMUser):
 Here's the final version of the profile:
 
 ```python
-from chainbench.user import EVMUser
+from chainbench.user import EvmUser
 from chainbench.util.rng import get_rng
 from locust import task, constant_pacing
 
 
-class OasisProfile(EVMUser):
+class OasisProfile(EvmUser):
     wait_time = constant_pacing(2)
 
     @task

--- a/docs/PROFILE.md
+++ b/docs/PROFILE.md
@@ -62,7 +62,7 @@ class OasisProfile(EvmUser):
 
     @task
     def get_block_by_number_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_block_by_number",
             method="eth_getBlockByNumber",
             params=self._block_params_factory(),
@@ -91,7 +91,7 @@ class OasisProfile(EvmUser):
 
     @task
     def get_block_by_number_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_block_by_number",
             method="eth_getBlockByNumber",
             params=self._block_params_factory(),
@@ -99,7 +99,7 @@ class OasisProfile(EvmUser):
 
     @task
     def get_syncing_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_syncing",
             method="eth_syncing",
         ),
@@ -118,7 +118,7 @@ from locust import task
 class BscProfile(EvmUser):
     @task(100)
     def call_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="call",
             method="eth_call",
             params=[
@@ -147,7 +147,7 @@ class OasisProfile(EvmUser):
 
     @task
     def get_block_by_number_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_block_by_number",
             method="eth_getBlockByNumber",
             params=self._block_params_factory(),
@@ -155,7 +155,7 @@ class OasisProfile(EvmUser):
 
     @task
     def get_transaction_by_hash_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_transaction_by_hash",
             method="eth_getTransactionByHash",
             params=self._transaction_by_hash_params_factory(get_rng()),
@@ -163,7 +163,7 @@ class OasisProfile(EvmUser):
 
     @task
     def get_syncing_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_syncing",
             method="eth_syncing",
         ),
@@ -184,7 +184,7 @@ class OasisProfile(EvmUser):
 
     @task
     def get_block_by_number_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_block_by_number",
             method="eth_getBlockByNumber",
             params=self._block_params_factory(),
@@ -192,7 +192,7 @@ class OasisProfile(EvmUser):
 
     @task
     def get_balance_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_balance",
             method="eth_getBalance",
             params=self._get_balance_params_factory(get_rng()),
@@ -200,7 +200,7 @@ class OasisProfile(EvmUser):
 
     @task
     def get_transaction_count_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_transaction_count",
             method="eth_getTransactionCount",
             params=self._get_balance_params_factory(get_rng()),
@@ -208,7 +208,7 @@ class OasisProfile(EvmUser):
 
     @task
     def get_code_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_code",
             method="eth_getCode",
             params=self._get_balance_params_factory(get_rng()),
@@ -216,7 +216,7 @@ class OasisProfile(EvmUser):
 
     @task
     def get_transaction_by_hash_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_transaction_by_hash",
             method="eth_getTransactionByHash",
             params=self._transaction_by_hash_params_factory(get_rng()),
@@ -224,7 +224,7 @@ class OasisProfile(EvmUser):
 
     @task
     def get_syncing_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_syncing",
             method="eth_syncing",
         ),
@@ -245,7 +245,7 @@ class OasisProfile(EvmUser):
 
     @task
     def get_block_by_number_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_block_by_number",
             method="eth_getBlockByNumber",
             params=self._block_params_factory(),
@@ -253,7 +253,7 @@ class OasisProfile(EvmUser):
 
     @task
     def get_balance_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_balance",
             method="eth_getBalance",
             params=self._get_balance_params_factory(get_rng()),
@@ -261,7 +261,7 @@ class OasisProfile(EvmUser):
 
     @task
     def get_transaction_count_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_transaction_count",
             method="eth_getTransactionCount",
             params=self._get_balance_params_factory(get_rng()),
@@ -269,7 +269,7 @@ class OasisProfile(EvmUser):
 
     @task
     def get_code_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_code",
             method="eth_getCode",
             params=self._get_balance_params_factory(get_rng()),
@@ -277,7 +277,7 @@ class OasisProfile(EvmUser):
 
     @task
     def get_transaction_by_hash_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_transaction_by_hash",
             method="eth_getTransactionByHash",
             params=self._transaction_by_hash_params_factory(get_rng()),
@@ -285,21 +285,21 @@ class OasisProfile(EvmUser):
 
     @task
     def get_block_number_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="block_number",
             method="eth_blockNumber",
         ),
 
     @task
     def get_syncing_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_syncing",
             method="eth_syncing",
         ),
 
     @task
     def get_block_transaction_count_by_number_task(self):
-        self.make_call(
+        self.make_rpc_call(
             name="get_block_transaction_count_by_number",
             method="eth_getBlockTransactionCountByNumber",
             params=self._random_block_number_params_factory(get_rng()),


### PR DESCRIPTION
## Description
- refactor JsonRPCUser to split the function to HttpUser and JsonRPCUser and add additional functionality to new HttpUser class
- add EthConsensusUser and EthConsensusMethods classes as base for creating Ethereum Consensus profiles, initially supporting only certain endpoints
- add EthConsensusTestData and other relevant classes for managing test data for Ethereum Consensus profiles
- other minor refactoring and code cleanup

## Issues Resolved
- fix issue where Chainbench does not exit cleanly if master runner exits before worker runner is ready
- fix issue where get_block_worker is started even though there is an exception in fetching test data