### PR TITLE
add more metadata to timescale db listener

### DIFF
--- a/chainbench/util/http.py
+++ b/chainbench/util/http.py
@@ -151,11 +151,11 @@ class HttpClient:
             "id": token_hex(8),
         }
 
-    def make_rpc_call(self, method: str, params: list[t.Any] | None = None) -> t.Any:
+    def make_rpc_call(self, method: str, params: list[t.Any] | None = None, path: str = "") -> t.Any:
         if params is None:
             params = []
 
-        response = self.post(data=self._make_body(method, params))
+        response = self.post(path=path, data=self._make_body(method, params))
 
         logger.debug(f"Making call to {self._host} with method {method} and params {params}")
         logger.debug(f"Response: {response.json}")


### PR DESCRIPTION
## Description
- add function to try to get client version of target node/endpoint
- add metadata such as chainbench version, target node host, client and version
- refactor get_master_command and get_worker_command into a single class and reduce code redundancy