### PR TITLE
Add support Hyperliquid

### DIFF
--- a/chainbench/test_data/evm.py
+++ b/chainbench/test_data/evm.py
@@ -397,6 +397,17 @@ class EvmNetwork:
             "start_block": 100000,
             "contract_addresses": [],
         },
+        999: {
+            "name": "hyperliquid-mainnet",
+            "start_block": 1,
+            "contract_addresses": [
+                "0x2df1c51e09aecf9cacb7bc98cb1742757f163df7",
+                "0x3333333333333333333333333333333333333333",
+                "0x2222222222222222222222222222222222222222",
+                "0x5555555555555555555555555555555555555555",
+                "0x510100d5143e011db24e2aa38abe85d73d5b2177",
+            ],
+        },
     }
 
 


### PR DESCRIPTION
## Description
- Added support for Hyperliquid network (chain ID 999) in the EVM network configuration
- Added common token contract addresses for Hyperliquid mainnet
- Configured start block and network name for Hyperliquid

## Issues Resolved
- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for a new blockchain network configuration, "hyperliquid-mainnet". This update enables the application to recognize and interact with the additional network, enhancing its connectivity options with preset operational parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->