### PR TITLE
Add hyperliquid support

### DIFF
--- a/chainbench/test_data/evm.py
+++ b/chainbench/test_data/evm.py
@@ -408,6 +408,14 @@ class EvmNetwork:
                 "0x47bb061C0204Af921F43DC73C7D7768d2672DdEE",
             ],
         },
+        998: {
+            "name": "hyperliquid-testnet",
+            "start_block": 1,
+            "contract_addresses": [
+                "0x72B0e1c7251511c076c6c7De4864DF06Ec24AC7B",
+                "0x928e4e3dFb1c39a6deE26506Cde76875E3a25ea4",
+            ],
+        },
     }
 
 

--- a/chainbench/test_data/evm.py
+++ b/chainbench/test_data/evm.py
@@ -397,6 +397,17 @@ class EvmNetwork:
             "start_block": 100000,
             "contract_addresses": [],
         },
+        999: {
+            "name": "hyperliquid-mainnet",
+            "start_block": 1,
+            "contract_addresses": [
+                "0x7f5aB8f7974FCcd857163E5DA649Eb2588201dF1",
+                "0x5555555555555555555555555555555555555555",
+                "0xfFaa4a3D97fE9107Cef8a3F48c069F577Ff76cC1",
+                "0x5748ae796AE46A4F1348a1693de4b50560485562",
+                "0x47bb061C0204Af921F43DC73C7D7768d2672DdEE",
+            ],
+        },
     }
 
 


### PR DESCRIPTION
## Description
- Add hyperliquid mainnet and testnet support.
- Add network IDs and erc20 contracts for eth_call method for hyperliquid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Hyperliquid mainnet and testnet networks with associated contract addresses, expanding the set of supported blockchain networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->