### PR TITLE
ci: keep the Docker build working on fork pull requests

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,9 +26,13 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          # list of Docker images to use as base name for tags
+          # List of Docker images to use as base name for tags.
+          # Repository variables are not exposed to pull_request runs from a
+          # fork, so vars.DOCKERHUB_ID is empty there and would produce an
+          # invalid tag ("/chainbench:pr-N"), failing the build before it
+          # starts. Fall back to a placeholder name — PR runs never push.
           images: |
-            ${{ vars.DOCKERHUB_ID }}/chainbench
+            ${{ vars.DOCKERHUB_ID || 'chainbench-ci' }}/chainbench
           # generate Docker tags based on the following events/attributes
           tags: |
             type=schedule

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,10 +1,5 @@
 name: Docker
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 on:
   release:
     types: [published]
@@ -26,22 +21,12 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          # List of Docker images to use as base name for tags.
-          #
-          # Repository variables are not exposed to pull_request runs from a
-          # fork, so vars.DOCKERHUB_ID is empty there and would produce an
-          # invalid tag ("/chainbench:pr-N"), failing the build before it
-          # starts. Fall back to a placeholder name on pull requests, which
-          # never push; releases keep vars.DOCKERHUB_ID so a missing variable
-          # still fails loudly instead of pushing under a placeholder name.
-          #
-          #   pull request + variable set -> the variable
-          #   pull request + variable unset -> chainbench-ci
-          #   release + variable set -> the variable
-          #   release + variable unset -> empty, fails on an invalid tag
+          # vars.DOCKERHUB_ID is empty on pull requests from a fork, which would
+          # yield the invalid tag "/chainbench:pr-N". Such runs never push, so a
+          # placeholder is safe there; releases keep the variable so a missing
+          # one fails at tag validation instead of pushing under a stray name.
           images: |
             ${{ github.event_name == 'pull_request' && (vars.DOCKERHUB_ID || 'chainbench-ci') || vars.DOCKERHUB_ID }}/chainbench
-          # generate Docker tags based on the following events/attributes
           tags: |
             type=schedule
             type=ref,event=branch
@@ -61,7 +46,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Build and push Docker image with Buildx (don't push on PR)
       - name: Build and push
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,12 +27,20 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           # List of Docker images to use as base name for tags.
+          #
           # Repository variables are not exposed to pull_request runs from a
           # fork, so vars.DOCKERHUB_ID is empty there and would produce an
           # invalid tag ("/chainbench:pr-N"), failing the build before it
-          # starts. Fall back to a placeholder name — PR runs never push.
+          # starts. Fall back to a placeholder name on pull requests, which
+          # never push; releases keep vars.DOCKERHUB_ID so a missing variable
+          # still fails loudly instead of pushing under a placeholder name.
+          #
+          #   pull request + variable set -> the variable
+          #   pull request + variable unset -> chainbench-ci
+          #   release + variable set -> the variable
+          #   release + variable unset -> empty, fails on an invalid tag
           images: |
-            ${{ vars.DOCKERHUB_ID || 'chainbench-ci' }}/chainbench
+            ${{ github.event_name == 'pull_request' && (vars.DOCKERHUB_ID || 'chainbench-ci') || vars.DOCKERHUB_ID }}/chainbench
           # generate Docker tags based on the following events/attributes
           tags: |
             type=schedule


### PR DESCRIPTION
## Problem

The `Docker` workflow fails on every pull request opened from a fork, before Docker ever reads the `Dockerfile`.

`docker/metadata-action` builds the image name from `${{ vars.DOCKERHUB_ID }}/chainbench`. Repository variables — like secrets — are not exposed to `pull_request` runs originating from a fork, so the expression resolves to an empty string and the action emits:

```
--tag /chainbench:pr-121
ERROR: failed to build: invalid tag "/chainbench:pr-121": invalid reference format
```

buildx rejects the reference and the job dies at the `Build and push` step. Nothing in the `Dockerfile` is executed, so the `build` check is a false negative: it reports failure regardless of the change, and it never validates the image for external contributors.

Seen on [#121](https://github.com/chainstacklabs/chainbench/pull/121) ([run](https://github.com/chainstacklabs/chainbench/actions/runs/30110317932/job/89555707862)), which is the first fork PR to touch the `Dockerfile`. Internal PRs are unaffected because the variable resolves there.

## Fix

Fall back to a placeholder image name on pull requests when the variable is unset:

```yaml
images: |
  ${{ github.event_name == 'pull_request' && (vars.DOCKERHUB_ID || 'chainbench-ci') || vars.DOCKERHUB_ID }}/chainbench
```

| Event | Variable | Image name |
| --- | --- | --- |
| pull request | set | the variable |
| pull request | unset | `chainbench-ci` |
| release | set | the variable |
| release | unset | empty — fails on an invalid tag, as today |

The placeholder is safe on pull requests because they never push: `push` is already gated on `github.event_name != 'pull_request'` and the registry login step is already skipped for PRs. The name only has to be syntactically valid.

Releases deliberately keep `vars.DOCKERHUB_ID` on its own. Substituting a placeholder there would turn a missing variable from an obvious tag-validation failure into a push attempt under a namespace we do not own — Docker Hub would deny it, but failing at the tag is the clearer signal.

## Effect

Fork PRs now run the real build with `push: false`, so the image is genuinely compiled and the check becomes meaningful for external contributions.

Since `pull_request` workflows run from the merge ref, #121 picks this up automatically once it lands — no rebase needed from the contributor.

## Testing

Workflow YAML parses and the expression is preserved. The behaviour itself is only observable on a fork PR run; this PR is internal, so its own `build` check exercises the unchanged path (variable present).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented Docker image tag behavior for base images.

* **Bug Fixes**
  * Improved pull-request image handling for forked repositories by preventing invalid tags.
  * Preserved standard image publishing behavior for configured Docker Hub accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
